### PR TITLE
Legg til Deltaker og repository

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
@@ -9,8 +9,6 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.coroutines.runBlocking
 import no.nav.amt.deltaker.bff.Environment.Companion.HTTP_CLIENT_TIMEOUT_MS
-import no.nav.amt.deltaker.bff.application.deltakerliste.DeltakerlisteRepository
-import no.nav.amt.deltaker.bff.application.deltakerliste.kafka.DeltakerlisteConsumer
 import no.nav.amt.deltaker.bff.application.isReadyKey
 import no.nav.amt.deltaker.bff.application.plugins.applicationConfig
 import no.nav.amt.deltaker.bff.application.plugins.configureAuthentication
@@ -24,6 +22,8 @@ import no.nav.amt.deltaker.bff.arrangor.ArrangorService
 import no.nav.amt.deltaker.bff.auth.AzureAdTokenClient
 import no.nav.amt.deltaker.bff.auth.TilgangskontrollService
 import no.nav.amt.deltaker.bff.db.Database
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteRepository
+import no.nav.amt.deltaker.bff.deltakerliste.kafka.DeltakerlisteConsumer
 import no.nav.poao_tilgang.client.PoaoTilgangCachedClient
 import no.nav.poao_tilgang.client.PoaoTilgangHttpClient
 

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/db/Database.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/db/Database.kt
@@ -5,7 +5,9 @@ import kotliquery.Session
 import kotliquery.sessionOf
 import kotliquery.using
 import no.nav.amt.deltaker.bff.Environment
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import org.flywaydb.core.Flyway
+import org.postgresql.util.PGobject
 import javax.sql.DataSource
 
 object Database {
@@ -48,4 +50,9 @@ object Database {
             .migrate()
             .migrations
             .size
+}
+
+fun toPGObject(value: Any) = PGobject().also {
+    it.type = "json"
+    it.value = objectMapper.writeValueAsString(value)
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/Deltaker.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/Deltaker.kt
@@ -1,0 +1,22 @@
+package no.nav.amt.deltaker.bff.deltaker
+
+import no.nav.amt.deltaker.bff.deltakerliste.Mal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class Deltaker(
+    val id: UUID,
+    val personident: String,
+    val deltakerlisteId: UUID,
+    val startdato: LocalDate?,
+    val sluttdato: LocalDate?,
+    val dagerPerUke: Float?,
+    val deltakelsesprosent: Float?,
+    val bakgrunnsinformasjon: String?,
+    val mal: List<Mal>,
+    val status: DeltakerStatus,
+    val sistEndretAv: String?,
+    val sistEndret: LocalDateTime,
+    val opprettet: LocalDateTime,
+)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/Deltaker.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/Deltaker.kt
@@ -16,7 +16,7 @@ data class Deltaker(
     val bakgrunnsinformasjon: String?,
     val mal: List<Mal>,
     val status: DeltakerStatus,
-    val sistEndretAv: String?,
+    val sistEndretAv: String,
     val sistEndret: LocalDateTime,
     val opprettet: LocalDateTime,
 )

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerRepository.kt
@@ -1,0 +1,158 @@
+package no.nav.amt.deltaker.bff.deltaker
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotliquery.Query
+import kotliquery.Row
+import kotliquery.queryOf
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.db.Database
+import no.nav.amt.deltaker.bff.db.toPGObject
+import java.util.UUID
+
+class DeltakerRepository {
+    fun rowMapper(row: Row) = Deltaker(
+        id = row.uuid("d.id"),
+        personident = row.string("d.personident"),
+        deltakerlisteId = row.uuid("d.deltakerliste_id"),
+        startdato = row.localDateOrNull("d.startdato"),
+        sluttdato = row.localDateOrNull("d.sluttdato"),
+        dagerPerUke = row.floatOrNull("d.dager_per_uke"),
+        deltakelsesprosent = row.floatOrNull("d.deltakelsesprosent"),
+        bakgrunnsinformasjon = row.stringOrNull("d.bakgrunnsinformasjon"),
+        mal = row.string("d.mal").let { objectMapper.readValue(it) },
+        status = DeltakerStatus(
+            id = row.uuid("ds.id"),
+            type = row.string("ds.type").let { DeltakerStatus.Type.valueOf(it) },
+            aarsak = row.stringOrNull("ds.aarsak")?.let { DeltakerStatus.Aarsak.valueOf(it) },
+            gyldigFra = row.localDateTime("ds.gyldig_fra"),
+            gyldigTil = row.localDateTimeOrNull("ds.gyldig_til"),
+            opprettet = row.localDateTime("ds.created_at"),
+        ),
+        sistEndretAv = row.stringOrNull("d.sist_endret_av"),
+        sistEndret = row.localDateTime("d.modified_at"),
+        opprettet = row.localDateTime("d.created_at"),
+    )
+
+    fun upsert(deltaker: Deltaker) = Database.query { session ->
+        val sql = """
+            insert into deltaker(
+                id, personident, deltakerliste_id, startdato, sluttdato, dager_per_uke, 
+                deltakelsesprosent, bakgrunnsinformasjon, mal, sist_endret_av
+            )
+            values (
+                :id, :personident, :deltakerlisteId, :startdato, :sluttdato, :dagerPerUke, 
+                :deltakelsesprosent, :bakgrunnsinformasjon, :mal, :sistEndretAv
+            )
+            on conflict (id) do update set 
+                personident          = :personident,
+                startdato            = :startdato,
+                sluttdato            = :sluttdato,
+                dager_per_uke        = :dagerPerUke,
+                deltakelsesprosent   = :deltakelsesprosent,
+                bakgrunnsinformasjon = :bakgrunnsinformasjon,
+                mal                  = :mal,
+                sist_endret_av       = :sistEndretAv,
+                modified_at          = :sistEndret
+        """.trimIndent()
+
+        val parameters = mapOf(
+            "id" to deltaker.id,
+            "personident" to deltaker.personident,
+            "deltakerlisteId" to deltaker.deltakerlisteId,
+            "startdato" to deltaker.startdato,
+            "sluttdato" to deltaker.sluttdato,
+            "dagerPerUke" to deltaker.dagerPerUke,
+            "deltakelsesprosent" to deltaker.deltakelsesprosent,
+            "bakgrunnsinformasjon" to deltaker.bakgrunnsinformasjon,
+            "mal" to toPGObject(deltaker.mal),
+            "sistEndretAv" to deltaker.sistEndretAv,
+            "sistEndret" to deltaker.sistEndret,
+        )
+
+        session.transaction { tx ->
+            tx.update(queryOf(sql, parameters))
+            tx.update(insertStatusQuery(deltaker.status, deltaker.id))
+            tx.update(deaktiverTidligereStatuserQuery(deltaker.status, deltaker.id))
+        }
+    }
+
+    fun get(id: UUID) = Database.query {
+        val sql = """
+            select d.id as "d.id",
+                   d.personident as "d.personident",
+                   d.deltakerliste_id as "d.deltakerliste_id",
+                   d.startdato as "d.startdato",
+                   d.sluttdato as "d.sluttdato",
+                   d.dager_per_uke as "d.dager_per_uke",
+                   d.deltakelsesprosent as "d.deltakelsesprosent",
+                   d.bakgrunnsinformasjon as "d.bakgrunnsinformasjon",
+                   d.mal as "d.mal",
+                   d.sist_endret_av as "d.sist_endret_av",
+                   d.created_at as "d.created_at",
+                   d.modified_at as "d.modified_at",
+                   ds.id as "ds.id",
+                   ds.deltaker_id as "ds.deltaker_id",
+                   ds.type as "ds.type",
+                   ds.aarsak as "ds.aarsak",
+                   ds.gyldig_fra as "ds.gyldig_fra",
+                   ds.gyldig_til as "ds.gyldig_til",
+                   ds.created_at as "ds.created_at",
+                   ds.modified_at as "ds.modified_at"
+            from deltaker d join deltaker_status ds on d.id = ds.deltaker_id
+            where d.id = :id and ds.gyldig_til is null
+        """.trimIndent()
+
+        val query = queryOf(sql, mapOf("id" to id)).map(::rowMapper).asSingle
+        it.run(query)
+    }
+
+    fun getDeltakerStatuser(deltakerId: UUID) = Database.query { session ->
+        val sql = """
+            select * from deltaker_status where deltaker_id = :deltaker_id
+        """.trimIndent()
+
+        val query = queryOf(sql, mapOf("deltaker_id" to deltakerId)).map {
+            DeltakerStatus(
+                id = it.uuid("id"),
+                type = it.string("type").let { t -> DeltakerStatus.Type.valueOf(t) },
+                aarsak = it.stringOrNull("aarsak")?.let { t -> DeltakerStatus.Aarsak.valueOf(t) },
+                gyldigFra = it.localDateTime("gyldig_fra"),
+                gyldigTil = it.localDateTimeOrNull("gyldig_til"),
+                opprettet = it.localDateTime("created_at"),
+            )
+        }
+            .asList
+
+        session.run(query)
+    }
+
+    private fun insertStatusQuery(status: DeltakerStatus, deltakerId: UUID): Query {
+        val sql = """
+            insert into deltaker_status(id, deltaker_id, type, aarsak, gyldig_fra) 
+            values (:id, :deltaker_id, :type, :aarsak, :gyldig_fra) 
+            on conflict (id) do nothing;
+        """.trimIndent()
+
+        val params = mapOf(
+            "id" to status.id,
+            "deltaker_id" to deltakerId,
+            "type" to status.type.name,
+            "aarsak" to status.aarsak?.name,
+            "gyldig_fra" to status.gyldigFra,
+        )
+
+        return queryOf(sql, params)
+    }
+
+    private fun deaktiverTidligereStatuserQuery(status: DeltakerStatus, deltakerId: UUID): Query {
+        val sql = """
+            update deltaker_status
+            set gyldig_til = current_timestamp
+            where deltaker_id = :deltaker_id 
+              and id != :id 
+              and gyldig_til is null;
+        """.trimIndent()
+
+        return queryOf(sql, mapOf("id" to status.id, "deltaker_id" to deltakerId))
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerRepository.kt
@@ -28,7 +28,7 @@ class DeltakerRepository {
             gyldigTil = row.localDateTimeOrNull("ds.gyldig_til"),
             opprettet = row.localDateTime("ds.created_at"),
         ),
-        sistEndretAv = row.stringOrNull("d.sist_endret_av"),
+        sistEndretAv = row.string("d.sist_endret_av"),
         sistEndret = row.localDateTime("d.modified_at"),
         opprettet = row.localDateTime("d.created_at"),
     )

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerStatus.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerStatus.kt
@@ -1,0 +1,45 @@
+package no.nav.amt.deltaker.bff.deltaker
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class DeltakerStatus(
+    val id: UUID,
+    val type: Type,
+    val aarsak: Aarsak?,
+    val gyldigFra: LocalDateTime,
+    val gyldigTil: LocalDateTime?,
+    val opprettet: LocalDateTime,
+) {
+    enum class Aarsak {
+        SYK, FATT_JOBB, TRENGER_ANNEN_STOTTE, FIKK_IKKE_PLASS, IKKE_MOTT, ANNET, AVLYST_KONTRAKT
+    }
+
+    enum class Type {
+        VENTER_PA_OPPSTART, DELTAR, HAR_SLUTTET, IKKE_AKTUELL, FEILREGISTRERT,
+        SOKT_INN, VURDERES, VENTELISTE, AVBRUTT, FULLFORT,
+        PABEGYNT_REGISTRERING,
+    }
+}
+
+val AVSLUTTENDE_STATUSER = listOf(
+    DeltakerStatus.Type.HAR_SLUTTET,
+    DeltakerStatus.Type.IKKE_AKTUELL,
+    DeltakerStatus.Type.FEILREGISTRERT,
+    DeltakerStatus.Type.AVBRUTT,
+    DeltakerStatus.Type.FULLFORT,
+)
+
+val VENTER_PAA_PLASS_STATUSER = listOf(
+    DeltakerStatus.Type.SOKT_INN,
+    DeltakerStatus.Type.VURDERES,
+    DeltakerStatus.Type.VENTELISTE,
+    DeltakerStatus.Type.PABEGYNT_REGISTRERING,
+)
+
+val STATUSER_SOM_KAN_SKJULES = listOf(
+    DeltakerStatus.Type.IKKE_AKTUELL,
+    DeltakerStatus.Type.HAR_SLUTTET,
+    DeltakerStatus.Type.AVBRUTT,
+    DeltakerStatus.Type.FULLFORT,
+)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/Deltakerliste.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/Deltakerliste.kt
@@ -52,3 +52,10 @@ data class Deltakerliste(
         Tiltak.Type.GRUFAGYRKE,
     )
 }
+
+data class Mal(
+    val visningstekst: String,
+    val type: String,
+    val valgt: Boolean,
+    val beskrivelse: String?,
+)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/Deltakerliste.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/Deltakerliste.kt
@@ -1,4 +1,4 @@
-package no.nav.amt.deltaker.bff.application.deltakerliste
+package no.nav.amt.deltaker.bff.deltakerliste
 
 import java.time.LocalDate
 import java.util.UUID
@@ -28,11 +28,11 @@ data class Deltakerliste(
 
         companion object {
             fun fromString(status: String) = when (status) {
-                "GJENNOMFORES" -> Deltakerliste.Status.GJENNOMFORES
-                "AVBRUTT" -> Deltakerliste.Status.AVBRUTT
-                "AVLYST" -> Deltakerliste.Status.AVLYST
-                "AVSLUTTET" -> Deltakerliste.Status.AVSLUTTET
-                "PLANLAGT", "APENT_FOR_INNSOK" -> Deltakerliste.Status.PLANLAGT
+                "GJENNOMFORES" -> GJENNOMFORES
+                "AVBRUTT" -> AVBRUTT
+                "AVLYST" -> AVLYST
+                "AVSLUTTET" -> AVSLUTTET
+                "PLANLAGT", "APENT_FOR_INNSOK" -> PLANLAGT
                 else -> error("Ukjent deltakerlistestatus: $status")
             }
         }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepository.kt
@@ -1,4 +1,4 @@
-package no.nav.amt.deltaker.bff.application.deltakerliste
+package no.nav.amt.deltaker.bff.deltakerliste
 
 import kotliquery.Row
 import kotliquery.queryOf

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/Tiltak.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/Tiltak.kt
@@ -1,4 +1,4 @@
-package no.nav.amt.deltaker.bff.application.deltakerliste
+package no.nav.amt.deltaker.bff.deltakerliste
 
 data class Tiltak(
     val navn: String,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumer.kt
@@ -1,10 +1,10 @@
-package no.nav.amt.deltaker.bff.application.deltakerliste.kafka
+package no.nav.amt.deltaker.bff.deltakerliste.kafka
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.amt.deltaker.bff.Environment
-import no.nav.amt.deltaker.bff.application.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.deltaker.bff.arrangor.ArrangorService
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.bff.kafka.ManagedKafkaConsumer
 import no.nav.amt.deltaker.bff.kafka.config.KafkaConfig
 import no.nav.amt.deltaker.bff.kafka.config.KafkaConfigImpl

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteDto.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteDto.kt
@@ -1,8 +1,8 @@
-package no.nav.amt.deltaker.bff.application.deltakerliste.kafka
+package no.nav.amt.deltaker.bff.deltakerliste.kafka
 
-import no.nav.amt.deltaker.bff.application.deltakerliste.Deltakerliste
-import no.nav.amt.deltaker.bff.application.deltakerliste.Tiltak
-import no.nav.amt.deltaker.bff.application.deltakerliste.arenaKodeTilTiltakstype
+import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
+import no.nav.amt.deltaker.bff.deltakerliste.Tiltak
+import no.nav.amt.deltaker.bff.deltakerliste.arenaKodeTilTiltakstype
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/main/resources/db/migration/V03__deltaker.sql
+++ b/src/main/resources/db/migration/V03__deltaker.sql
@@ -9,7 +9,7 @@ create table deltaker
     deltakelsesprosent   double precision,
     bakgrunnsinformasjon text,
     mal                  jsonb                                              not null,
-    sist_endret_av       varchar,
+    sist_endret_av       varchar                                            not null,
     created_at           timestamp with time zone default CURRENT_TIMESTAMP not null,
     modified_at          timestamp with time zone default CURRENT_TIMESTAMP not null
 );

--- a/src/main/resources/db/migration/V03__deltaker.sql
+++ b/src/main/resources/db/migration/V03__deltaker.sql
@@ -1,0 +1,27 @@
+create table deltaker
+(
+    id                   uuid                                               not null primary key,
+    personident          varchar                                            not null,
+    deltakerliste_id     uuid                                               not null references deltakerliste (id),
+    startdato            date,
+    sluttdato            date,
+    dager_per_uke        double precision,
+    deltakelsesprosent   double precision,
+    bakgrunnsinformasjon text,
+    mal                  jsonb                                              not null,
+    sist_endret_av       varchar,
+    created_at           timestamp with time zone default CURRENT_TIMESTAMP not null,
+    modified_at          timestamp with time zone default CURRENT_TIMESTAMP not null
+);
+
+create table deltaker_status
+(
+    id          uuid                                               not null primary key,
+    deltaker_id uuid references deltaker,
+    type        varchar                                            not null,
+    aarsak      varchar,
+    gyldig_fra  timestamp with time zone                           not null,
+    gyldig_til  timestamp with time zone,
+    created_at  timestamp with time zone default CURRENT_TIMESTAMP not null,
+    modified_at timestamp with time zone default CURRENT_TIMESTAMP not null
+);

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerRepositoryTest.kt
@@ -84,8 +84,8 @@ class DeltakerRepositoryTest {
         a.status.id shouldBe b.status.id
         a.status.type shouldBe b.status.type
         a.status.aarsak shouldBe b.status.aarsak
-        a.status.gyldigFra shouldBe b.status.gyldigFra
-        a.status.gyldigTil shouldBe b.status.gyldigTil
+        a.status.gyldigFra shouldBeCloseTo b.status.gyldigFra
+        a.status.gyldigTil shouldBeCloseTo b.status.gyldigTil
         a.status.opprettet shouldBeCloseTo b.status.opprettet
         a.sistEndretAv shouldBe b.sistEndretAv
         a.sistEndret shouldBeCloseTo b.sistEndret

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerRepositoryTest.kt
@@ -1,0 +1,94 @@
+package no.nav.amt.deltaker.bff.deltaker
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
+import no.nav.amt.deltaker.bff.utils.data.TestData
+import no.nav.amt.deltaker.bff.utils.data.TestRepository
+import no.nav.amt.deltaker.bff.utils.shouldBeCloseTo
+import org.junit.BeforeClass
+import org.junit.Test
+import java.time.LocalDate
+
+class DeltakerRepositoryTest {
+    companion object {
+        lateinit var repository: DeltakerRepository
+
+        @JvmStatic
+        @BeforeClass
+        fun setup() {
+            SingletonPostgresContainer.start()
+            repository = DeltakerRepository()
+        }
+    }
+
+    @Test
+    fun `upsert - ny deltaker - insertes`() {
+        val deltaker = TestData.lagDeltaker()
+        val deltakerliste = TestData.lagDeltakerliste(id = deltaker.deltakerlisteId)
+        TestRepository.insert(deltakerliste)
+
+        repository.upsert(deltaker)
+        sammenlignDeltakere(repository.get(deltaker.id)!!, deltaker)
+    }
+
+    @Test
+    fun `upsert - oppdatert deltaker - oppdaterer`() {
+        val deltaker = TestData.lagDeltaker()
+        TestRepository.insert(deltaker)
+
+        val oppdatertDeltaker = deltaker.copy(
+            personident = TestData.randomIdent(),
+            startdato = LocalDate.now().plusWeeks(1),
+            sluttdato = LocalDate.now().plusWeeks(5),
+            dagerPerUke = 1F,
+            deltakelsesprosent = 20F,
+            sistEndretAv = TestData.randomNavIdent(),
+        )
+
+        repository.upsert(oppdatertDeltaker)
+        sammenlignDeltakere(repository.get(deltaker.id)!!, oppdatertDeltaker)
+    }
+
+    @Test
+    fun `upsert - ny status - inserter ny status og deaktiverer gammel`() {
+        val deltaker = TestData.lagDeltaker(
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+        )
+        TestRepository.insert(deltaker)
+
+        val oppdatertDeltaker = deltaker.copy(
+            status = TestData.lagDeltakerStatus(
+                type = DeltakerStatus.Type.HAR_SLUTTET,
+                aarsak = DeltakerStatus.Aarsak.FATT_JOBB,
+            ),
+        )
+
+        repository.upsert(oppdatertDeltaker)
+        sammenlignDeltakere(repository.get(deltaker.id)!!, oppdatertDeltaker)
+
+        val statuser = repository.getDeltakerStatuser(deltaker.id)
+        statuser.first { it.id == deltaker.status.id }.gyldigTil shouldNotBe null
+        statuser.first { it.id == oppdatertDeltaker.status.id }.gyldigTil shouldBe null
+    }
+
+    private fun sammenlignDeltakere(a: Deltaker, b: Deltaker) {
+        a.id shouldBe b.id
+        a.personident shouldBe b.personident
+        a.startdato shouldBe b.startdato
+        a.sluttdato shouldBe b.sluttdato
+        a.dagerPerUke shouldBe b.dagerPerUke
+        a.deltakelsesprosent shouldBe b.deltakelsesprosent
+        a.bakgrunnsinformasjon shouldBe b.bakgrunnsinformasjon
+        a.mal shouldBe b.mal
+        a.status.id shouldBe b.status.id
+        a.status.type shouldBe b.status.type
+        a.status.aarsak shouldBe b.status.aarsak
+        a.status.gyldigFra shouldBe b.status.gyldigFra
+        a.status.gyldigTil shouldBe b.status.gyldigTil
+        a.status.opprettet shouldBeCloseTo b.status.opprettet
+        a.sistEndretAv shouldBe b.sistEndretAv
+        a.sistEndret shouldBeCloseTo b.sistEndret
+        a.opprettet shouldBeCloseTo b.opprettet
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepositoryTest.kt
@@ -1,7 +1,6 @@
 package no.nav.amt.deltaker.bff.deltakerliste
 
 import io.kotest.matchers.shouldBe
-import no.nav.amt.deltaker.bff.application.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumerTest.kt
@@ -2,11 +2,10 @@ package no.nav.amt.deltaker.bff.deltakerliste.kafka
 
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.runBlocking
-import no.nav.amt.deltaker.bff.application.deltakerliste.DeltakerlisteRepository
-import no.nav.amt.deltaker.bff.application.deltakerliste.kafka.DeltakerlisteConsumer
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.deltaker.bff.arrangor.ArrangorRepository
 import no.nav.amt.deltaker.bff.arrangor.ArrangorService
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/DateTimeAssertions.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/DateTimeAssertions.kt
@@ -1,6 +1,7 @@
 package no.nav.amt.deltaker.bff.utils
 
 import io.kotest.matchers.date.shouldBeWithin
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import java.time.Duration
 import java.time.LocalDateTime
@@ -21,7 +22,10 @@ infix fun LocalDateTime.shouldBeEqualTo(expected: LocalDateTime?) {
     expected!!.shouldBeWithin(Duration.ofSeconds(1), this)
 }
 
-infix fun LocalDateTime.shouldBeCloseTo(expected: LocalDateTime?) {
-    expected shouldNotBe null
-    expected!!.shouldBeWithin(Duration.ofSeconds(10), this)
+infix fun LocalDateTime?.shouldBeCloseTo(expected: LocalDateTime?) {
+    if (this == null) {
+        expected shouldBe null
+    } else {
+        expected!!.shouldBeWithin(Duration.ofSeconds(10), this)
+    }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/DateTimeAssertions.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/DateTimeAssertions.kt
@@ -1,0 +1,27 @@
+package no.nav.amt.deltaker.bff.utils
+
+import io.kotest.matchers.date.shouldBeWithin
+import io.kotest.matchers.shouldNotBe
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZonedDateTime
+
+infix fun ZonedDateTime.shouldBeEqualTo(expected: ZonedDateTime?) {
+    expected shouldNotBe null
+    expected!!.shouldBeWithin(Duration.ofSeconds(1), this)
+}
+
+infix fun ZonedDateTime.shouldBeCloseTo(expected: ZonedDateTime?) {
+    expected shouldNotBe null
+    expected!!.shouldBeWithin(Duration.ofSeconds(10), this)
+}
+
+infix fun LocalDateTime.shouldBeEqualTo(expected: LocalDateTime?) {
+    expected shouldNotBe null
+    expected!!.shouldBeWithin(Duration.ofSeconds(1), this)
+}
+
+infix fun LocalDateTime.shouldBeCloseTo(expected: LocalDateTime?) {
+    expected shouldNotBe null
+    expected!!.shouldBeWithin(Duration.ofSeconds(10), this)
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -1,14 +1,18 @@
 package no.nav.amt.deltaker.bff.utils.data
 
 import no.nav.amt.deltaker.bff.arrangor.Arrangor
+import no.nav.amt.deltaker.bff.deltaker.Deltaker
+import no.nav.amt.deltaker.bff.deltaker.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
+import no.nav.amt.deltaker.bff.deltakerliste.Mal
 import no.nav.amt.deltaker.bff.deltakerliste.Tiltak
 import no.nav.amt.deltaker.bff.deltakerliste.kafka.DeltakerlisteDto
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 object TestData {
-    fun randomIdent() = (10_00_19_00_00_000..31_12_20_99_99_999).random().toString()
+    fun randomIdent() = (10_00_00_00_000..31_12_00_99_999).random().toString()
 
     fun randomNavIdent() = ('A'..'Z').random().toString() + (100_000..999_999).random().toString()
 
@@ -55,6 +59,45 @@ object TestData {
         virksomhetsnummer = arrangor.organisasjonsnummer,
         oppstart = deltakerliste.oppstart,
     )
+
+    fun lagDeltaker(
+        id: UUID = UUID.randomUUID(),
+        personident: String = randomIdent(),
+        deltakerlisteId: UUID = UUID.randomUUID(),
+        startdato: LocalDate? = LocalDate.now().minusMonths(3),
+        sluttdato: LocalDate? = LocalDate.now().minusDays(1),
+        dagerPerUke: Float? = 5F,
+        deltakelsesprosent: Float? = 100F,
+        bakgrunnsinformasjon: String? = "Søkes inn fordi...",
+        mal: List<Mal> = emptyList(),
+        status: DeltakerStatus = lagDeltakerStatus(type = DeltakerStatus.Type.HAR_SLUTTET),
+        sistEndretAv: String? = randomNavIdent(),
+        sistEndret: LocalDateTime = LocalDateTime.now(),
+        opprettet: LocalDateTime = LocalDateTime.now(),
+    ) = Deltaker(
+        id,
+        personident,
+        deltakerlisteId,
+        startdato,
+        sluttdato,
+        dagerPerUke,
+        deltakelsesprosent,
+        bakgrunnsinformasjon,
+        mal,
+        status,
+        sistEndretAv,
+        sistEndret,
+        opprettet,
+    )
+
+    fun lagDeltakerStatus(
+        id: UUID = UUID.randomUUID(),
+        type: DeltakerStatus.Type = DeltakerStatus.Type.DELTAR,
+        aarsak: DeltakerStatus.Aarsak? = null,
+        gyldigFra: LocalDateTime = LocalDateTime.now(),
+        gyldigTil: LocalDateTime? = null,
+        opprettet: LocalDateTime = gyldigFra,
+    ) = DeltakerStatus(id, type, aarsak, gyldigFra, gyldigTil, opprettet)
 
     private fun finnOppstartstype(type: Tiltak.Type) = when (type) {
         Tiltak.Type.JOBBK,

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -1,9 +1,9 @@
 package no.nav.amt.deltaker.bff.utils.data
 
-import no.nav.amt.deltaker.bff.application.deltakerliste.Deltakerliste
-import no.nav.amt.deltaker.bff.application.deltakerliste.Tiltak
-import no.nav.amt.deltaker.bff.application.deltakerliste.kafka.DeltakerlisteDto
 import no.nav.amt.deltaker.bff.arrangor.Arrangor
+import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
+import no.nav.amt.deltaker.bff.deltakerliste.Tiltak
+import no.nav.amt.deltaker.bff.deltakerliste.kafka.DeltakerlisteDto
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -71,7 +71,7 @@ object TestData {
         bakgrunnsinformasjon: String? = "Søkes inn fordi...",
         mal: List<Mal> = emptyList(),
         status: DeltakerStatus = lagDeltakerStatus(type = DeltakerStatus.Type.HAR_SLUTTET),
-        sistEndretAv: String? = randomNavIdent(),
+        sistEndretAv: String = randomNavIdent(),
         sistEndret: LocalDateTime = LocalDateTime.now(),
         opprettet: LocalDateTime = LocalDateTime.now(),
     ) = Deltaker(

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
@@ -1,9 +1,9 @@
 package no.nav.amt.deltaker.bff.utils.data
 
 import kotliquery.queryOf
-import no.nav.amt.deltaker.bff.application.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.bff.arrangor.Arrangor
 import no.nav.amt.deltaker.bff.db.Database
+import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
 import org.slf4j.LoggerFactory
 
 object TestRepository {

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
@@ -3,8 +3,12 @@ package no.nav.amt.deltaker.bff.utils.data
 import kotliquery.queryOf
 import no.nav.amt.deltaker.bff.arrangor.Arrangor
 import no.nav.amt.deltaker.bff.db.Database
+import no.nav.amt.deltaker.bff.db.toPGObject
+import no.nav.amt.deltaker.bff.deltaker.Deltaker
+import no.nav.amt.deltaker.bff.deltaker.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 object TestRepository {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -58,5 +62,65 @@ object TestRepository {
                 ),
             )
         }
+    }
+
+    fun insert(
+        deltaker: Deltaker,
+        deltakerliste: Deltakerliste = TestData.lagDeltakerliste(id = deltaker.deltakerlisteId),
+    ) = Database.query { session ->
+        try {
+            insert(deltakerliste)
+        } catch (e: Exception) {
+            log.warn("Deltakerliste med id ${deltakerliste.id} er allerede opprettet")
+        }
+
+        val sql = """
+            insert into deltaker(
+                id, personident, deltakerliste_id, startdato, sluttdato, dager_per_uke, 
+                deltakelsesprosent, bakgrunnsinformasjon, mal, sist_endret_av, modified_at, created_at
+            )
+            values (
+                :id, :personident, :deltakerlisteId, :startdato, :sluttdato, :dagerPerUke, 
+                :deltakelsesprosent, :bakgrunnsinformasjon, :mal, :sistEndretAv, :modifiedAt, :createdAt
+            )
+        """.trimIndent()
+
+        val parameters = mapOf(
+            "id" to deltaker.id,
+            "personident" to deltaker.personident,
+            "deltakerlisteId" to deltaker.deltakerlisteId,
+            "startdato" to deltaker.startdato,
+            "sluttdato" to deltaker.sluttdato,
+            "dagerPerUke" to deltaker.dagerPerUke,
+            "deltakelsesprosent" to deltaker.deltakelsesprosent,
+            "bakgrunnsinformasjon" to deltaker.bakgrunnsinformasjon,
+            "mal" to toPGObject(deltaker.mal),
+            "sistEndretAv" to deltaker.sistEndretAv,
+            "modifiedAt" to deltaker.sistEndret,
+            "createdAt" to deltaker.opprettet,
+        )
+
+        session.update(queryOf(sql, parameters))
+        insert(deltaker.status, deltaker.id)
+    }
+
+    fun insert(status: DeltakerStatus, deltakerId: UUID) = Database.query {
+        val sql = """
+            insert into deltaker_status(id, deltaker_id, type, aarsak, gyldig_fra, gyldig_til, created_at) 
+            values (:id, :deltaker_id, :type, :aarsak, :gyldig_fra, :gyldig_til, :created_at) 
+            on conflict (id) do nothing;
+        """.trimIndent()
+
+        val params = mapOf(
+            "id" to status.id,
+            "deltaker_id" to deltakerId,
+            "type" to status.type.name,
+            "aarsak" to status.aarsak?.name,
+            "gyldig_fra" to status.gyldigFra,
+            "gyldig_til" to status.gyldigTil,
+            "created_at" to status.opprettet,
+        )
+
+        it.update(queryOf(sql, params))
     }
 }


### PR DESCRIPTION
Jeg har gjort det sånn passe likt som en deltaker er i amt-tiltak for å ha et utgangspunkt, men det er ikke helt likt så det kan bli noen utfordringer om/når vi må lese inn de gamle deltakerne i denne løsningen.

- feltet `registrertDato` har jeg valgt og ikke videreføre enda, jeg vet ikke hva det feltet egentlig betyr, om det er Arena sin `createdAt`? Vil det være noe annet i ny løsning?
- Deltakerstatuser:
    - amt-tiltak sine statuser har ingen `gyldigTil` bare en bool `aktiv` personlig foretrekker jeg isteden å ha en `gyldigTil` men det kan bli kronglete å sette riktig `gyldigTil` på de statusene vi har fra før, man må i såfall prøve å se på statusene i rekkefølge og ta `gyldigFra` på status nummer 2 og sette den som `gyldigTil` på status nummer 1 :shrug:
    - Det ville vært fint å få idene på statusene som finnes i amt-tiltak og lest de inn her.
    - Kanskje det bør være en egen service/repo for deltakerstatuser, hvis vi skal håndheve forretningsreglene rundt overgang mellom statuser her.

Det er sikkert mer jeg har glemt i farta.