### PR TITLE
Lagre navansatt

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -48,6 +48,7 @@ spec:
     outbound:
       rules:
         - application: amt-arrangor
+        - application: amt-person-service
         - application: poao-tilgang
           namespace: poao
   env:
@@ -59,6 +60,10 @@ spec:
       value: api://dev-gcp.poao.poao-tilgang/.default
     - name: POAO_TILGANG_URL
       value: http://poao-tilgang.poao
+    - name: AMT_PERSONSERVICE_SCOPE
+      value: api://dev-gcp.amt.amt-person-service/.default
+    - name: AMT_PERSONSERVICE_URL
+      value: http://amt-person-service
 
   gcp:
     sqlInstances:

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
@@ -28,6 +28,8 @@ import no.nav.amt.deltaker.bff.deltaker.db.DeltakerRepository
 import no.nav.amt.deltaker.bff.deltaker.db.DeltakerSamtykkeRepository
 import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.bff.deltakerliste.kafka.DeltakerlisteConsumer
+import no.nav.amt.deltaker.bff.navansatt.NavAnsattConsumer
+import no.nav.amt.deltaker.bff.navansatt.NavAnsattRepository
 import no.nav.poao_tilgang.client.PoaoTilgangCachedClient
 import no.nav.poao_tilgang.client.PoaoTilgangHttpClient
 
@@ -77,14 +79,17 @@ fun Application.module() {
 
     val arrangorRepository = ArrangorRepository()
     val deltakerlisteRepository = DeltakerlisteRepository()
+    val navAnsattRepository = NavAnsattRepository()
 
     val arrangorService = ArrangorService(arrangorRepository, amtArrangorClient)
 
     val arrangorConsumer = ArrangorConsumer(arrangorRepository)
     val deltakerlisteConsumer = DeltakerlisteConsumer(deltakerlisteRepository, arrangorService)
+    val navAnsattConsumer = NavAnsattConsumer(navAnsattRepository)
 
     arrangorConsumer.run()
     deltakerlisteConsumer.run()
+    navAnsattConsumer.run()
 
     val poaoTilgangCachedClient = PoaoTilgangCachedClient.createDefaultCacheClient(
         PoaoTilgangHttpClient(

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
@@ -111,7 +111,7 @@ fun Application.module() {
     val deltakerRepository = DeltakerRepository()
     val samtykkeRepository = DeltakerSamtykkeRepository()
     val historikkRepository = DeltakerHistorikkRepository()
-    val deltakerService = DeltakerService(deltakerRepository, deltakerlisteRepository, samtykkeRepository, historikkRepository)
+    val deltakerService = DeltakerService(deltakerRepository, deltakerlisteRepository, samtykkeRepository, historikkRepository, navAnsattService)
 
     configureAuthentication(environment)
     configureRouting(tilgangskontrollService, deltakerService)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
@@ -28,8 +28,10 @@ import no.nav.amt.deltaker.bff.deltaker.db.DeltakerRepository
 import no.nav.amt.deltaker.bff.deltaker.db.DeltakerSamtykkeRepository
 import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.bff.deltakerliste.kafka.DeltakerlisteConsumer
+import no.nav.amt.deltaker.bff.navansatt.AmtPersonServiceClient
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattConsumer
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattRepository
+import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
 import no.nav.poao_tilgang.client.PoaoTilgangCachedClient
 import no.nav.poao_tilgang.client.PoaoTilgangHttpClient
 
@@ -64,17 +66,24 @@ fun Application.module() {
     }
 
     val azureAdTokenClient = AzureAdTokenClient(
-        environment.azureAdTokenUrl,
-        environment.azureClientId,
-        environment.azureClientSecret,
-        httpClient,
+        azureAdTokenUrl = environment.azureAdTokenUrl,
+        clientId = environment.azureClientId,
+        clientSecret = environment.azureClientSecret,
+        httpClient = httpClient,
     )
 
     val amtArrangorClient = AmtArrangorClient(
-        environment.amtArrangorUrl,
-        environment.amtArrangorScope,
-        httpClient,
-        azureAdTokenClient,
+        baseUrl = environment.amtArrangorUrl,
+        scope = environment.amtArrangorScope,
+        httpClient = httpClient,
+        azureAdTokenClient = azureAdTokenClient,
+    )
+
+    val amtPersonServiceClient = AmtPersonServiceClient(
+        baseUrl = environment.amtPersonServiceUrl,
+        scope = environment.amtPersonServiceScope,
+        httpClient = httpClient,
+        azureAdTokenClient = azureAdTokenClient,
     )
 
     val arrangorRepository = ArrangorRepository()
@@ -82,10 +91,11 @@ fun Application.module() {
     val navAnsattRepository = NavAnsattRepository()
 
     val arrangorService = ArrangorService(arrangorRepository, amtArrangorClient)
+    val navAnsattService = NavAnsattService(navAnsattRepository, amtPersonServiceClient)
 
     val arrangorConsumer = ArrangorConsumer(arrangorRepository)
     val deltakerlisteConsumer = DeltakerlisteConsumer(deltakerlisteRepository, arrangorService)
-    val navAnsattConsumer = NavAnsattConsumer(navAnsattRepository)
+    val navAnsattConsumer = NavAnsattConsumer(navAnsattService)
 
     arrangorConsumer.run()
     deltakerlisteConsumer.run()

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Environment.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Environment.kt
@@ -15,6 +15,8 @@ data class Environment(
     val amtArrangorScope: String = getEnvVar(AMT_ARRANGOR_SCOPE_KEY),
     val poaoTilgangUrl: String = getEnvVar(POAO_TILGANG_URL_KEY),
     val poaoTilgangScope: String = getEnvVar(POAO_TILGANG_SCOPE_KEY),
+    val amtPersonServiceUrl: String = getEnvVar(AMT_PERSONSERVICE_URL_KEY),
+    val amtPersonServiceScope: String = getEnvVar(AMT_PERSONSERVICE_SCOPE_KEY),
 ) {
 
     companion object {
@@ -32,6 +34,8 @@ data class Environment(
         const val AMT_ARRANGOR_SCOPE_KEY = "AMT_ARRANGOR_SCOPE"
 
         const val AMT_NAV_ANSATT_TOPIC = "amt.nav-ansatt-personalia-v1"
+        const val AMT_PERSONSERVICE_URL_KEY = "AMT_PERSONSERVICE_URL"
+        const val AMT_PERSONSERVICE_SCOPE_KEY = "AMT_PERSONSERVICE_SCOPE"
 
         const val AZURE_AD_TOKEN_URL_KEY = "AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"
         const val AZURE_APP_CLIENT_SECRET_KEY = "AZURE_APP_CLIENT_SECRET"

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Environment.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Environment.kt
@@ -31,6 +31,8 @@ data class Environment(
         const val AMT_ARRANGOR_URL_KEY = "AMT_ARRANGOR_URL"
         const val AMT_ARRANGOR_SCOPE_KEY = "AMT_ARRANGOR_SCOPE"
 
+        const val AMT_NAV_ANSATT_TOPIC = "amt.nav-ansatt-personalia-v1"
+
         const val AZURE_AD_TOKEN_URL_KEY = "AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"
         const val AZURE_APP_CLIENT_SECRET_KEY = "AZURE_APP_CLIENT_SECRET"
         const val AZURE_APP_CLIENT_ID_KEY = "AZURE_APP_CLIENT_ID"

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/AmtPersonServiceClient.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/AmtPersonServiceClient.kt
@@ -1,0 +1,41 @@
+package no.nav.amt.deltaker.bff.navansatt
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.auth.AzureAdTokenClient
+
+class AmtPersonServiceClient(
+    private val baseUrl: String,
+    private val scope: String,
+    private val httpClient: HttpClient,
+    private val azureAdTokenClient: AzureAdTokenClient,
+) {
+    suspend fun hentNavAnsatt(navIdent: String): NavAnsatt {
+        val token = azureAdTokenClient.getMachineToMachineToken(scope)
+        val response = httpClient.post("$baseUrl/api/nav-ansatt") {
+            header(HttpHeaders.Authorization, token)
+            contentType(ContentType.Application.Json)
+            setBody(objectMapper.writeValueAsString(NavAnsattRequest(navIdent)))
+        }
+        if (!response.status.isSuccess()) {
+            error(
+                "Kunne ikke hente nav-ansatt med ident $navIdent fra amt-person-service. " +
+                    "Status=${response.status.value} error=${response.bodyAsText()}",
+            )
+        }
+        return response.body()
+    }
+}
+
+data class NavAnsattRequest(
+    val navIdent: String,
+)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsatt.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsatt.kt
@@ -1,0 +1,9 @@
+package no.nav.amt.deltaker.bff.navansatt
+
+import java.util.UUID
+
+data class NavAnsatt(
+    val id: UUID,
+    val navident: String,
+    val navn: String,
+)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumer.kt
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class NavAnsattConsumer(
-    private val repository: NavAnsattRepository,
+    private val navAnsattService: NavAnsattService,
     kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -30,10 +30,10 @@ class NavAnsattConsumer(
 
     fun consumeNavAnsatt(id: UUID, navAnsatt: String?) {
         if (navAnsatt == null) {
-            repository.delete(id)
+            navAnsattService.slettNavAnsatt(id)
             log.info("Slettet navansatt med id $id")
         } else {
-            repository.upsert(objectMapper.readValue(navAnsatt))
+            navAnsattService.oppdaterNavAnsatt(objectMapper.readValue(navAnsatt))
             log.info("Lagret navansatt med id $id")
         }
     }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumer.kt
@@ -1,0 +1,44 @@
+package no.nav.amt.deltaker.bff.navansatt
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.amt.deltaker.bff.Environment
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.kafka.ManagedKafkaConsumer
+import no.nav.amt.deltaker.bff.kafka.config.KafkaConfig
+import no.nav.amt.deltaker.bff.kafka.config.KafkaConfigImpl
+import no.nav.amt.deltaker.bff.kafka.config.LocalKafkaConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.UUIDDeserializer
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class NavAnsattConsumer(
+    private val repository: NavAnsattRepository,
+    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private val consumer = ManagedKafkaConsumer(
+        topic = Environment.AMT_NAV_ANSATT_TOPIC,
+        config = kafkaConfig.consumerConfig(
+            keyDeserializer = UUIDDeserializer(),
+            valueDeserializer = StringDeserializer(),
+            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
+        ),
+        consume = ::consumeNavAnsatt,
+    )
+
+    fun consumeNavAnsatt(id: UUID, navAnsatt: String?) {
+        if (navAnsatt == null) {
+            repository.delete(id)
+            log.info("Slettet navansatt med id $id")
+        } else {
+            repository.upsert(objectMapper.readValue(navAnsatt))
+            log.info("Lagret navansatt med id $id")
+        }
+    }
+
+    fun run() {
+        consumer.run()
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattRepository.kt
@@ -1,0 +1,69 @@
+package no.nav.amt.deltaker.bff.navansatt
+
+import kotliquery.Row
+import kotliquery.queryOf
+import no.nav.amt.deltaker.bff.db.Database
+import java.time.LocalDateTime
+import java.util.UUID
+
+class NavAnsattRepository {
+    private fun rowMapper(row: Row) = NavAnsatt(
+        id = row.uuid("id"),
+        navident = row.string("nav_ident"),
+        navn = row.string("navn"),
+    )
+
+    fun upsert(navAnsatt: NavAnsatt) {
+        val sql = """
+            INSERT INTO nav_ansatt(id, nav_ident, navn, modified_at)
+            VALUES (:id, :nav_ident, :navn, :modified_at) 
+            ON CONFLICT (id) DO UPDATE SET
+                nav_ident = :nav_ident,
+                navn = :navn,
+                modified_at = :modified_at
+        """.trimIndent()
+
+        Database.query {
+            val query = queryOf(
+                sql,
+                mapOf(
+                    "id" to navAnsatt.id,
+                    "nav_ident" to navAnsatt.navident,
+                    "navn" to navAnsatt.navn,
+                    "modified_at" to LocalDateTime.now(),
+                ),
+            )
+            it.update(query)
+        }
+    }
+
+    fun get(id: UUID): NavAnsatt? {
+        return Database.query {
+            val query = queryOf(
+                """select * from nav_ansatt where id = :id""",
+                mapOf("id" to id),
+            ).map(::rowMapper).asSingle
+
+            it.run(query)
+        }
+    }
+
+    fun get(navIdent: String): NavAnsatt? {
+        return Database.query {
+            val query = queryOf(
+                """select * from nav_ansatt where nav_ident = :nav_ident""",
+                mapOf("nav_ident" to navIdent),
+            ).map(::rowMapper).asSingle
+
+            it.run(query)
+        }
+    }
+
+    fun delete(id: UUID) = Database.query {
+        val query = queryOf(
+            """delete from nav_ansatt where id = :id""",
+            mapOf("id" to id),
+        )
+        it.update(query)
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattService.kt
@@ -9,7 +9,7 @@ class NavAnsattService(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    suspend fun hentNavAnsatt(navIdent: String): NavAnsatt {
+    suspend fun hentEllerOpprettNavAnsatt(navIdent: String): NavAnsatt {
         repository.get(navIdent)?.let { return it }
 
         log.info("Fant ikke nav-ansatt med ident $navIdent, henter fra amt-person-service")

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattService.kt
@@ -1,0 +1,28 @@
+package no.nav.amt.deltaker.bff.navansatt
+
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class NavAnsattService(
+    private val repository: NavAnsattRepository,
+    private val amtPersonServiceClient: AmtPersonServiceClient,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    suspend fun hentNavAnsatt(navIdent: String): NavAnsatt {
+        repository.get(navIdent)?.let { return it }
+
+        log.info("Fant ikke nav-ansatt med ident $navIdent, henter fra amt-person-service")
+        val navAnsatt = amtPersonServiceClient.hentNavAnsatt(navIdent)
+        oppdaterNavAnsatt(navAnsatt)
+        return navAnsatt
+    }
+
+    fun oppdaterNavAnsatt(navAnsatt: NavAnsatt) {
+        repository.upsert(navAnsatt)
+    }
+
+    fun slettNavAnsatt(navAnsattId: UUID) {
+        repository.delete(navAnsattId)
+    }
+}

--- a/src/main/resources/db/migration/V06__nav-ansatt.sql
+++ b/src/main/resources/db/migration/V06__nav-ansatt.sql
@@ -1,0 +1,11 @@
+CREATE TABLE nav_ansatt
+(
+    id          uuid primary key,
+    nav_ident   varchar                  not null,
+    navn        varchar                  not null,
+    created_at  timestamp with time zone not null default current_timestamp,
+    modified_at timestamp with time zone not null default current_timestamp,
+    unique (nav_ident)
+);
+
+create index nav_ansatt_nav_ident_idx on nav_ansatt (nav_ident);

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
@@ -96,7 +96,7 @@ class DeltakerApiTest {
     fun `post deltaker - har tilgang - returnerer deltaker`() = testApplication {
         val deltakerResponse = getDeltakerResponse()
         coEvery { poaoTilgangCachedClient.evaluatePolicy(any()) } returns ApiResult(null, Decision.Permit)
-        every { deltakerService.opprettDeltaker(any(), any(), any()) } returns deltakerResponse
+        coEvery { deltakerService.opprettDeltaker(any(), any(), any()) } returns deltakerResponse
         setUpTestApplication()
         client.post("/deltaker") { postRequest(pameldingRequest) }.apply {
             TestCase.assertEquals(HttpStatusCode.OK, status)
@@ -107,7 +107,7 @@ class DeltakerApiTest {
     @Test
     fun `post deltaker - deltakerliste finnes ikke - reurnerer 404`() = testApplication {
         coEvery { poaoTilgangCachedClient.evaluatePolicy(any()) } returns ApiResult(null, Decision.Permit)
-        every {
+        coEvery {
             deltakerService.opprettDeltaker(
                 any(),
                 any(),
@@ -125,7 +125,7 @@ class DeltakerApiTest {
         coEvery { poaoTilgangCachedClient.evaluatePolicy(any()) } returns ApiResult(null, Decision.Permit)
         val deltaker = TestData.lagDeltaker()
         every { deltakerService.get(deltaker.id) } returns deltaker
-        every { deltakerService.opprettForslag(deltaker, any(), any()) } returns Unit
+        coEvery { deltakerService.opprettForslag(deltaker, any(), any()) } returns Unit
 
         setUpTestApplication()
         client.post("/pamelding/${deltaker.id}") { postRequest(forslagRequest) }.apply {
@@ -148,7 +148,7 @@ class DeltakerApiTest {
         coEvery { poaoTilgangCachedClient.evaluatePolicy(any()) } returns ApiResult(null, Decision.Permit)
         val deltaker = TestData.lagDeltaker()
         every { deltakerService.get(deltaker.id) } returns deltaker
-        every { deltakerService.meldPaUtenGodkjenning(deltaker, any(), any()) } returns Unit
+        coEvery { deltakerService.meldPaUtenGodkjenning(deltaker, any(), any()) } returns Unit
 
         setUpTestApplication()
         client.post("/pamelding/${deltaker.id}/utenGodkjenning") { postRequest(pameldingUtenGodkjenningRequest) }.apply {
@@ -197,7 +197,7 @@ class DeltakerApiTest {
         val deltaker = TestData.lagDeltaker()
         every { deltakerService.get(deltaker.id) } returns deltaker
         val oppdatertDeltakerResponse = getDeltakerResponse(deltakerId = deltaker.id, statustype = DeltakerStatus.Type.VENTER_PA_OPPSTART, bakgrunnsinformasjon = bakgrunnsinformasjonRequest.bakgrunnsinformasjon)
-        every { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.BAKGRUNNSINFORMASJON, any(), any()) } returns oppdatertDeltakerResponse
+        coEvery { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.BAKGRUNNSINFORMASJON, any(), any()) } returns oppdatertDeltakerResponse
 
         setUpTestApplication()
         client.post("/deltaker/${deltaker.id}/bakgrunnsinformasjon") { postRequest(bakgrunnsinformasjonRequest) }.apply {
@@ -211,7 +211,7 @@ class DeltakerApiTest {
         coEvery { poaoTilgangCachedClient.evaluatePolicy(any()) } returns ApiResult(null, Decision.Permit)
         val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.HAR_SLUTTET), sluttdato = LocalDate.now().minusMonths(1))
         every { deltakerService.get(deltaker.id) } returns deltaker
-        every { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.BAKGRUNNSINFORMASJON, any(), any()) } throws IllegalArgumentException("Deltaker har sluttet")
+        coEvery { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.BAKGRUNNSINFORMASJON, any(), any()) } throws IllegalArgumentException("Deltaker har sluttet")
 
         setUpTestApplication()
         client.post("/deltaker/${deltaker.id}/bakgrunnsinformasjon") { postRequest(bakgrunnsinformasjonRequest) }.apply {
@@ -225,7 +225,7 @@ class DeltakerApiTest {
         val deltaker = TestData.lagDeltaker()
         every { deltakerService.get(deltaker.id) } returns deltaker
         val oppdatertDeltakerResponse = getDeltakerResponse(deltakerId = deltaker.id, statustype = DeltakerStatus.Type.VENTER_PA_OPPSTART, mal = malRequest.mal)
-        every { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.MAL, any(), any()) } returns oppdatertDeltakerResponse
+        coEvery { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.MAL, any(), any()) } returns oppdatertDeltakerResponse
 
         setUpTestApplication()
         client.post("/deltaker/${deltaker.id}/mal") { postRequest(malRequest) }.apply {
@@ -240,7 +240,7 @@ class DeltakerApiTest {
         val deltaker = TestData.lagDeltaker()
         every { deltakerService.get(deltaker.id) } returns deltaker
         val oppdatertDeltakerResponse = getDeltakerResponse(deltakerId = deltaker.id, statustype = DeltakerStatus.Type.VENTER_PA_OPPSTART, dagerPerUke = deltakelsesmengdeRequest.dagerPerUke, deltakelsesprosent = deltakelsesmengdeRequest.deltakelsesprosent)
-        every { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.DELTAKELSESMENGDE, any(), any()) } returns oppdatertDeltakerResponse
+        coEvery { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.DELTAKELSESMENGDE, any(), any()) } returns oppdatertDeltakerResponse
 
         setUpTestApplication()
         client.post("/deltaker/${deltaker.id}/deltakelsesmengde") { postRequest(deltakelsesmengdeRequest) }.apply {
@@ -255,7 +255,7 @@ class DeltakerApiTest {
         val deltaker = TestData.lagDeltaker()
         every { deltakerService.get(deltaker.id) } returns deltaker
         val oppdatertDeltakerResponse = getDeltakerResponse(deltakerId = deltaker.id, statustype = DeltakerStatus.Type.VENTER_PA_OPPSTART, startdato = startdatoRequest.startdato)
-        every { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.STARTDATO, any(), any()) } returns oppdatertDeltakerResponse
+        coEvery { deltakerService.oppdaterDeltaker(deltaker, DeltakerEndringType.STARTDATO, any(), any()) } returns oppdatertDeltakerResponse
 
         setUpTestApplication()
         client.post("/deltaker/${deltaker.id}/startdato") { postRequest(startdatoRequest) }.apply {

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumerTest.kt
@@ -1,6 +1,7 @@
 package no.nav.amt.deltaker.bff.navansatt
 
 import io.kotest.matchers.shouldBe
+import io.mockk.mockk
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
@@ -8,6 +9,7 @@ import org.junit.BeforeClass
 import org.junit.Test
 
 class NavAnsattConsumerTest {
+    private val amtPersonServiceClient = mockk<AmtPersonServiceClient>()
     companion object {
         lateinit var repository: NavAnsattRepository
 
@@ -22,7 +24,7 @@ class NavAnsattConsumerTest {
     @Test
     fun `consumeNavAnsatt - ny navansatt - upserter`() {
         val navAnsatt = TestData.lagNavAnsatt()
-        val navAnsattConsumer = NavAnsattConsumer(repository)
+        val navAnsattConsumer = NavAnsattConsumer(NavAnsattService(repository, amtPersonServiceClient))
 
         navAnsattConsumer.consumeNavAnsatt(navAnsatt.id, objectMapper.writeValueAsString(navAnsatt))
 
@@ -34,7 +36,7 @@ class NavAnsattConsumerTest {
         val navAnsatt = TestData.lagNavAnsatt()
         repository.upsert(navAnsatt)
         val oppdatertNavAnsatt = navAnsatt.copy(navn = "Nytt Navn")
-        val navAnsattConsumer = NavAnsattConsumer(repository)
+        val navAnsattConsumer = NavAnsattConsumer(NavAnsattService(repository, amtPersonServiceClient))
 
         navAnsattConsumer.consumeNavAnsatt(navAnsatt.id, objectMapper.writeValueAsString(oppdatertNavAnsatt))
 
@@ -45,7 +47,7 @@ class NavAnsattConsumerTest {
     fun `consumeNavAnsatt - tombstonet navansatt - sletter`() {
         val navAnsatt = TestData.lagNavAnsatt()
         repository.upsert(navAnsatt)
-        val navAnsattConsumer = NavAnsattConsumer(repository)
+        val navAnsattConsumer = NavAnsattConsumer(NavAnsattService(repository, amtPersonServiceClient))
 
         navAnsattConsumer.consumeNavAnsatt(navAnsatt.id, null)
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumerTest.kt
@@ -1,0 +1,54 @@
+package no.nav.amt.deltaker.bff.navansatt
+
+import io.kotest.matchers.shouldBe
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
+import no.nav.amt.deltaker.bff.utils.data.TestData
+import org.junit.BeforeClass
+import org.junit.Test
+
+class NavAnsattConsumerTest {
+    companion object {
+        lateinit var repository: NavAnsattRepository
+
+        @JvmStatic
+        @BeforeClass
+        fun setup() {
+            SingletonPostgresContainer.start()
+            repository = NavAnsattRepository()
+        }
+    }
+
+    @Test
+    fun `consumeNavAnsatt - ny navansatt - upserter`() {
+        val navAnsatt = TestData.lagNavAnsatt()
+        val navAnsattConsumer = NavAnsattConsumer(repository)
+
+        navAnsattConsumer.consumeNavAnsatt(navAnsatt.id, objectMapper.writeValueAsString(navAnsatt))
+
+        repository.get(navAnsatt.id) shouldBe navAnsatt
+    }
+
+    @Test
+    fun `consumeNavAnsatt - oppdatert navansatt - upserter`() {
+        val navAnsatt = TestData.lagNavAnsatt()
+        repository.upsert(navAnsatt)
+        val oppdatertNavAnsatt = navAnsatt.copy(navn = "Nytt Navn")
+        val navAnsattConsumer = NavAnsattConsumer(repository)
+
+        navAnsattConsumer.consumeNavAnsatt(navAnsatt.id, objectMapper.writeValueAsString(oppdatertNavAnsatt))
+
+        repository.get(navAnsatt.id) shouldBe oppdatertNavAnsatt
+    }
+
+    @Test
+    fun `consumeNavAnsatt - tombstonet navansatt - sletter`() {
+        val navAnsatt = TestData.lagNavAnsatt()
+        repository.upsert(navAnsatt)
+        val navAnsattConsumer = NavAnsattConsumer(repository)
+
+        navAnsattConsumer.consumeNavAnsatt(navAnsatt.id, null)
+
+        repository.get(navAnsatt.id) shouldBe null
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattServiceTest.kt
@@ -24,19 +24,19 @@ class NavAnsattServiceTest {
     }
 
     @Test
-    fun `hentNavAnsatt - navansatt finnes i db - henter fra db`() {
+    fun `hentEllerOpprettNavAnsatt - navansatt finnes i db - henter fra db`() {
         val navAnsatt = TestData.lagNavAnsatt()
         repository.upsert(navAnsatt)
         val navAnsattService = NavAnsattService(repository, mockk<AmtPersonServiceClient>())
 
         runBlocking {
-            val navAnsattFraDb = navAnsattService.hentNavAnsatt(navAnsatt.navident)
+            val navAnsattFraDb = navAnsattService.hentEllerOpprettNavAnsatt(navAnsatt.navident)
             navAnsattFraDb shouldBe navAnsatt
         }
     }
 
     @Test
-    fun `hentNavAnsatt - navansatt finnes ikke i db - henter fra personservice og lagrer`() {
+    fun `hentEllerOpprettNavAnsatt - navansatt finnes ikke i db - henter fra personservice og lagrer`() {
         val navAnsattResponse = TestData.lagNavAnsatt()
         val httpClient = mockHttpClient(objectMapper.writeValueAsString(navAnsattResponse))
         val amtPersonServiceClient = AmtPersonServiceClient(
@@ -48,7 +48,7 @@ class NavAnsattServiceTest {
         val navAnsattService = NavAnsattService(repository, amtPersonServiceClient)
 
         runBlocking {
-            val navAnsatt = navAnsattService.hentNavAnsatt(navAnsattResponse.navident)
+            val navAnsatt = navAnsattService.hentEllerOpprettNavAnsatt(navAnsattResponse.navident)
 
             navAnsatt shouldBe navAnsattResponse
             repository.get(navAnsattResponse.id) shouldBe navAnsattResponse

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattServiceTest.kt
@@ -1,0 +1,80 @@
+package no.nav.amt.deltaker.bff.navansatt
+
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
+import no.nav.amt.deltaker.bff.utils.data.TestData
+import no.nav.amt.deltaker.bff.utils.mockAzureAdClient
+import no.nav.amt.deltaker.bff.utils.mockHttpClient
+import org.junit.BeforeClass
+import org.junit.Test
+
+class NavAnsattServiceTest {
+    companion object {
+        lateinit var repository: NavAnsattRepository
+
+        @JvmStatic
+        @BeforeClass
+        fun setup() {
+            SingletonPostgresContainer.start()
+            repository = NavAnsattRepository()
+        }
+    }
+
+    @Test
+    fun `hentNavAnsatt - navansatt finnes i db - henter fra db`() {
+        val navAnsatt = TestData.lagNavAnsatt()
+        repository.upsert(navAnsatt)
+        val navAnsattService = NavAnsattService(repository, mockk<AmtPersonServiceClient>())
+
+        runBlocking {
+            val navAnsattFraDb = navAnsattService.hentNavAnsatt(navAnsatt.navident)
+            navAnsattFraDb shouldBe navAnsatt
+        }
+    }
+
+    @Test
+    fun `hentNavAnsatt - navansatt finnes ikke i db - henter fra personservice og lagrer`() {
+        val navAnsattResponse = TestData.lagNavAnsatt()
+        val httpClient = mockHttpClient(objectMapper.writeValueAsString(navAnsattResponse))
+        val amtPersonServiceClient = AmtPersonServiceClient(
+            baseUrl = "http://amt-person-service",
+            scope = "scope",
+            httpClient = httpClient,
+            azureAdTokenClient = mockAzureAdClient(),
+        )
+        val navAnsattService = NavAnsattService(repository, amtPersonServiceClient)
+
+        runBlocking {
+            val navAnsatt = navAnsattService.hentNavAnsatt(navAnsattResponse.navident)
+
+            navAnsatt shouldBe navAnsattResponse
+            repository.get(navAnsattResponse.id) shouldBe navAnsattResponse
+        }
+    }
+
+    @Test
+    fun `oppdaterNavAnsatt - navansatt finnes - blir oppdatert`() {
+        val navAnsatt = TestData.lagNavAnsatt()
+        repository.upsert(navAnsatt)
+        val oppdatertNavAnsatt = navAnsatt.copy(navn = "Nytt Navn")
+        val navAnsattService = NavAnsattService(repository, mockk<AmtPersonServiceClient>())
+
+        navAnsattService.oppdaterNavAnsatt(oppdatertNavAnsatt)
+
+        repository.get(navAnsatt.id) shouldBe oppdatertNavAnsatt
+    }
+
+    @Test
+    fun `slettNavAnsatt - navansatt blir slettet`() {
+        val navAnsatt = TestData.lagNavAnsatt()
+        repository.upsert(navAnsatt)
+        val navAnsattService = NavAnsattService(repository, mockk<AmtPersonServiceClient>())
+
+        navAnsattService.slettNavAnsatt(navAnsatt.id)
+
+        repository.get(navAnsatt.id) shouldBe null
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/MockHttpClient.kt
@@ -16,6 +16,8 @@ import no.nav.amt.deltaker.bff.arrangor.AmtArrangorClient
 import no.nav.amt.deltaker.bff.arrangor.Arrangor
 import no.nav.amt.deltaker.bff.arrangor.ArrangorDto
 import no.nav.amt.deltaker.bff.auth.AzureAdTokenClient
+import no.nav.amt.deltaker.bff.navansatt.AmtPersonServiceClient
+import no.nav.amt.deltaker.bff.navansatt.NavAnsatt
 import no.nav.amt.deltaker.bff.utils.data.TestData
 
 fun mockHttpClient(response: String): HttpClient {
@@ -44,6 +46,15 @@ fun mockAmtArrangorClient(arrangor: Arrangor = TestData.lagArrangor()): AmtArran
         baseUrl = "https://amt-arrangor",
         scope = "amt.arrangor.scope",
         httpClient = mockHttpClient(objectMapper.writeValueAsString(response)),
+        azureAdTokenClient = mockAzureAdClient(),
+    )
+}
+
+fun mockAmtPersonServiceClient(navAnsatt: NavAnsatt = TestData.lagNavAnsatt()): AmtPersonServiceClient {
+    return AmtPersonServiceClient(
+        baseUrl = "https://amt-person-service",
+        scope = "amt.person-service.scope",
+        httpClient = mockHttpClient(objectMapper.writeValueAsString(navAnsatt)),
         azureAdTokenClient = mockAzureAdClient(),
     )
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -13,6 +13,7 @@ import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.bff.deltakerliste.Mal
 import no.nav.amt.deltaker.bff.deltakerliste.Tiltak
 import no.nav.amt.deltaker.bff.deltakerliste.kafka.DeltakerlisteDto
+import no.nav.amt.deltaker.bff.navansatt.NavAnsatt
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -138,6 +139,12 @@ object TestData {
         endretAv: String = randomNavIdent(),
         endret: LocalDateTime = LocalDateTime.now(),
     ) = DeltakerHistorikk(id, deltakerId, endringType, endring, endretAv, endret)
+
+    fun lagNavAnsatt(
+        id: UUID = UUID.randomUUID(),
+        navIdent: String = randomNavIdent(),
+        navn: String = "Veileder Veiledersen",
+    ) = NavAnsatt(id, navIdent, navn)
 
     private fun finnOppstartstype(type: Tiltak.Type) = when (type) {
         Tiltak.Type.JOBBK,


### PR DESCRIPTION
https://trello.com/c/S0LpMpx4/1243-f%C3%A5-navn-p%C3%A5-nav-ansatt-fra-amt-personservice-inn-i-deltaker-bff

Vi kommer til å få behov for å vise navn på nav-ansatt som har gjort endringer på deltaker (eller meldt noen på tiltak). Ved endring/påmelding av deltaker sjekker vi derfor om navansatt finnes i databasen, og hvis ikke henter vi den fra amt-person-service. 

Jeg har valgt å beholde navidenten som den som har gjort endringen i deltaker-tabellen i stedet for å koble mot en id i nav-ansatt-tabellen. Grunnen til det er at hvis vi av en eller annen grunn mangler den ansatte i tabellen (kanskje hen har sluttet) så kan vi vise nav-identen som en fallback-løsning. Det gjøres i mange systemer i dag allerede, og nav-identen er noe mange har et forhold til. Å vise en uuid som en gang tilhørte en ansatt vil ikke gi noe verdi for de som skal bruke dette. 