### PR TITLE
Legg til Deltakerliste i Deltaker

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApi.kt
@@ -21,6 +21,7 @@ import no.nav.amt.deltaker.bff.deltaker.api.model.EndreStartdatoRequest
 import no.nav.amt.deltaker.bff.deltaker.api.model.PameldingRequest
 import no.nav.amt.deltaker.bff.deltaker.api.model.PameldingUtenGodkjenningRequest
 import no.nav.amt.deltaker.bff.deltaker.api.model.UtkastRequest
+import no.nav.amt.deltaker.bff.deltaker.api.model.toDeltakerResponse
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltaker.model.GodkjenningAvNav
 import no.nav.amt.deltaker.bff.deltaker.model.OppdatertDeltaker
@@ -47,13 +48,13 @@ fun Routing.registerDeltakerApi(
                 opprettetAv = navIdent,
                 opprettetAvEnhet = enhetsnummer,
             )
-            call.respond(deltaker)
+            call.respond(deltaker.toDeltakerResponse())
         }
 
         post("/pamelding/{deltakerId}") {
             val navIdent = getNavIdent()
             val request = call.receive<UtkastRequest>()
-            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"]))
+            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"])).getOrThrow()
             val enhetsnummer = call.request.header("aktiv-enhet")
 
             tilgangskontrollService.verifiserSkrivetilgang(getNavAnsattAzureId(), deltaker.personident)
@@ -77,7 +78,7 @@ fun Routing.registerDeltakerApi(
         post("/pamelding/{deltakerId}/utenGodkjenning") {
             val navIdent = getNavIdent()
             val request = call.receive<PameldingUtenGodkjenningRequest>()
-            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"]))
+            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"])).getOrThrow()
             val enhetsnummer = call.request.header("aktiv-enhet")
 
             tilgangskontrollService.verifiserSkrivetilgang(getNavAnsattAzureId(), deltaker.personident)
@@ -106,7 +107,7 @@ fun Routing.registerDeltakerApi(
         delete("/pamelding/{deltakerId}") {
             val navIdent = getNavIdent()
             val deltakerId = UUID.fromString(call.parameters["deltakerId"])
-            val deltaker = deltakerService.get(deltakerId)
+            val deltaker = deltakerService.get(deltakerId).getOrThrow()
 
             tilgangskontrollService.verifiserSkrivetilgang(getNavAnsattAzureId(), deltaker.personident)
 
@@ -124,7 +125,7 @@ fun Routing.registerDeltakerApi(
         post("/deltaker/{deltakerId}/bakgrunnsinformasjon") {
             val navIdent = getNavIdent()
             val request = call.receive<EndreBakgrunnsinformasjonRequest>()
-            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"]))
+            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"])).getOrThrow()
             val enhetsnummer = call.request.header("aktiv-enhet")
 
             tilgangskontrollService.verifiserSkrivetilgang(getNavAnsattAzureId(), deltaker.personident)
@@ -136,13 +137,13 @@ fun Routing.registerDeltakerApi(
                 endretAv = navIdent,
                 endretAvEnhet = enhetsnummer,
             )
-            call.respond(oppdatertDeltaker)
+            call.respond(oppdatertDeltaker.toDeltakerResponse())
         }
 
         post("/deltaker/{deltakerId}/mal") {
             val navIdent = getNavIdent()
             val request = call.receive<EndreMalRequest>()
-            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"]))
+            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"])).getOrThrow()
             val enhetsnummer = call.request.header("aktiv-enhet")
 
             tilgangskontrollService.verifiserSkrivetilgang(getNavAnsattAzureId(), deltaker.personident)
@@ -154,13 +155,13 @@ fun Routing.registerDeltakerApi(
                 endretAv = navIdent,
                 endretAvEnhet = enhetsnummer,
             )
-            call.respond(oppdatertDeltaker)
+            call.respond(oppdatertDeltaker.toDeltakerResponse())
         }
 
         post("/deltaker/{deltakerId}/deltakelsesmengde") {
             val navIdent = getNavIdent()
             val request = call.receive<EndreDeltakelsesmengdeRequest>()
-            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"]))
+            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"])).getOrThrow()
             val enhetsnummer = call.request.header("aktiv-enhet")
 
             tilgangskontrollService.verifiserSkrivetilgang(getNavAnsattAzureId(), deltaker.personident)
@@ -175,13 +176,13 @@ fun Routing.registerDeltakerApi(
                 endretAv = navIdent,
                 endretAvEnhet = enhetsnummer,
             )
-            call.respond(oppdatertDeltaker)
+            call.respond(oppdatertDeltaker.toDeltakerResponse())
         }
 
         post("/deltaker/{deltakerId}/startdato") {
             val navIdent = getNavIdent()
             val request = call.receive<EndreStartdatoRequest>()
-            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"]))
+            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"])).getOrThrow()
             val enhetsnummer = call.request.header("aktiv-enhet")
 
             tilgangskontrollService.verifiserSkrivetilgang(getNavAnsattAzureId(), deltaker.personident)
@@ -193,16 +194,16 @@ fun Routing.registerDeltakerApi(
                 endretAv = navIdent,
                 endretAvEnhet = enhetsnummer,
             )
-            call.respond(oppdatertDeltaker)
+            call.respond(oppdatertDeltaker.toDeltakerResponse())
         }
 
         get("/deltaker/{deltakerId}") {
             val navIdent = getNavIdent()
-            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"]))
+            val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"])).getOrThrow()
             tilgangskontrollService.verifiserLesetilgang(getNavAnsattAzureId(), deltaker.personident)
             log.info("NAV-ident $navIdent har gjort oppslag på deltaker med id $deltaker")
 
-            call.respond(deltakerService.getDeltakerResponse(deltaker))
+            call.respond(deltaker.toDeltakerResponse())
         }
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponse.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponse.kt
@@ -1,8 +1,10 @@
 package no.nav.amt.deltaker.bff.deltaker.api.model
 
+import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltaker.model.endringshistorikk.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.endringshistorikk.DeltakerEndringType
+import no.nav.amt.deltaker.bff.deltaker.model.endringshistorikk.DeltakerHistorikk
 import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.bff.deltakerliste.Mal
 import no.nav.amt.deltaker.bff.deltakerliste.Tiltak
@@ -22,7 +24,6 @@ data class DeltakerResponse(
     val mal: List<Mal>,
     val sistEndretAv: String,
     val sistEndretAvEnhet: String?,
-    val historikk: List<DeltakerHistorikkDto>,
 )
 
 data class DeltakerlisteDTO(
@@ -39,4 +40,34 @@ data class DeltakerHistorikkDto(
     val endretAv: String,
     val endretAvEnhet: String?,
     val endret: LocalDateTime,
+)
+
+fun Deltaker.toDeltakerResponse(): DeltakerResponse {
+    return DeltakerResponse(
+        deltakerId = id,
+        deltakerliste = DeltakerlisteDTO(
+            deltakerlisteId = deltakerliste.id,
+            deltakerlisteNavn = deltakerliste.navn,
+            tiltakstype = deltakerliste.tiltak.type,
+            arrangorNavn = deltakerliste.arrangor.navn,
+            oppstartstype = deltakerliste.getOppstartstype(),
+        ),
+        status = status,
+        startdato = startdato,
+        sluttdato = sluttdato,
+        dagerPerUke = dagerPerUke,
+        deltakelsesprosent = deltakelsesprosent,
+        bakgrunnsinformasjon = bakgrunnsinformasjon,
+        mal = mal,
+        sistEndretAv = sistEndretAv,
+        sistEndretAvEnhet = sistEndretAvEnhet,
+    )
+}
+
+private fun DeltakerHistorikk.toDeltakerHistorikkDto() = DeltakerHistorikkDto(
+    endringType = endringType,
+    endring = endring,
+    endretAv = endretAv,
+    endretAvEnhet = endretAvEnhet,
+    endret = endret,
 )

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltaker.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltaker.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.deltaker.bff.deltaker.model
 
+import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.bff.deltakerliste.Mal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -8,7 +9,7 @@ import java.util.UUID
 data class Deltaker(
     val id: UUID,
     val personident: String,
-    val deltakerlisteId: UUID,
+    val deltakerliste: Deltakerliste,
     val startdato: LocalDate?,
     val sluttdato: LocalDate?,
     val dagerPerUke: Float?,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepository.kt
@@ -114,6 +114,7 @@ class DeltakerlisteRepository {
             mapOf("id" to id),
         ).map(::rowMapper).asSingle
 
-        it.run(query)
+        it.run(query)?.let { dl -> Result.success(dl) }
+            ?: Result.failure(NoSuchElementException("Fant ikke deltakerliste med id $id"))
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -27,11 +27,10 @@ class DeltakerRepositoryTest {
     @Test
     fun `upsert - ny deltaker - insertes`() {
         val deltaker = TestData.lagDeltaker()
-        val deltakerliste = TestData.lagDeltakerliste(id = deltaker.deltakerlisteId)
-        TestRepository.insert(deltakerliste)
+        TestRepository.insert(deltaker.deltakerliste)
 
         repository.upsert(deltaker)
-        sammenlignDeltakere(repository.get(deltaker.id)!!, deltaker)
+        sammenlignDeltakere(repository.get(deltaker.id).getOrThrow(), deltaker)
     }
 
     @Test
@@ -49,7 +48,7 @@ class DeltakerRepositoryTest {
         )
 
         repository.upsert(oppdatertDeltaker)
-        sammenlignDeltakere(repository.get(deltaker.id)!!, oppdatertDeltaker)
+        sammenlignDeltakere(repository.get(deltaker.id).getOrThrow(), oppdatertDeltaker)
     }
 
     @Test
@@ -67,7 +66,7 @@ class DeltakerRepositoryTest {
         )
 
         repository.upsert(oppdatertDeltaker)
-        sammenlignDeltakere(repository.get(deltaker.id)!!, oppdatertDeltaker)
+        sammenlignDeltakere(repository.get(deltaker.id).getOrThrow(), oppdatertDeltaker)
 
         val statuser = repository.getDeltakerStatuser(deltaker.id)
         statuser.first { it.id == deltaker.status.id }.gyldigTil shouldNotBe null
@@ -77,13 +76,12 @@ class DeltakerRepositoryTest {
     @Test
     fun `slettKladd - ny deltaker - insertes`() {
         val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.KLADD))
-        val deltakerliste = TestData.lagDeltakerliste(id = deltaker.deltakerlisteId)
-        TestRepository.insert(deltakerliste)
+        TestRepository.insert(deltaker.deltakerliste)
         repository.upsert(deltaker)
 
         repository.slettKladd(deltaker.id)
 
-        repository.get(deltaker.id) shouldBe null
+        repository.get(deltaker.id).isFailure shouldBe true
     }
 
     @Test
@@ -92,26 +90,30 @@ class DeltakerRepositoryTest {
         TestRepository.insert(navAnsatt)
         val navEnhet = TestData.lagNavEnhet()
         TestRepository.insert(navEnhet)
-        val deltaker = TestData.lagDeltaker(sistEndretAv = navAnsatt.navIdent, sistEndretAvEnhet = navEnhet.enhetsnummer)
+        val deltaker = TestData.lagDeltaker(
+            sistEndretAv = navAnsatt.navIdent,
+            sistEndretAvEnhet = navEnhet.enhetsnummer,
+        )
         TestRepository.insert(deltaker)
 
-        val deltakerFraDb = repository.get(deltaker.id)
+        val deltakerFraDb = repository.get(deltaker.id).getOrThrow()
 
-        deltakerFraDb?.sistEndretAv shouldBe navAnsatt.navn
-        deltakerFraDb?.sistEndretAvEnhet shouldBe navEnhet.navn
+        deltakerFraDb.sistEndretAv shouldBe navAnsatt.navn
+        deltakerFraDb.sistEndretAvEnhet shouldBe navEnhet.navn
     }
 
     @Test
     fun `get - deltaker, ansatt og enhet finnes ikke - returnerer navident og enhetsnummer`() {
         val navAnsatt = TestData.lagNavAnsatt()
         val navEnhet = TestData.lagNavEnhet()
-        val deltaker = TestData.lagDeltaker(sistEndretAv = navAnsatt.navIdent, sistEndretAvEnhet = navEnhet.enhetsnummer)
+        val deltaker =
+            TestData.lagDeltaker(sistEndretAv = navAnsatt.navIdent, sistEndretAvEnhet = navEnhet.enhetsnummer)
         TestRepository.insert(deltaker)
 
-        val deltakerFraDb = repository.get(deltaker.id)
+        val deltakerFraDb = repository.get(deltaker.id).getOrThrow()
 
-        deltakerFraDb?.sistEndretAv shouldBe navAnsatt.navIdent
-        deltakerFraDb?.sistEndretAvEnhet shouldBe navEnhet.enhetsnummer
+        deltakerFraDb.sistEndretAv shouldBe navAnsatt.navIdent
+        deltakerFraDb.sistEndretAvEnhet shouldBe navEnhet.enhetsnummer
     }
 }
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepositoryTest.kt
@@ -29,7 +29,7 @@ class DeltakerlisteRepositoryTest {
 
         repository.upsert(deltakerliste)
 
-        repository.get(deltakerliste.id) shouldBe deltakerliste
+        repository.get(deltakerliste.id).getOrNull() shouldBe deltakerliste
     }
 
     @Test
@@ -44,7 +44,7 @@ class DeltakerlisteRepositoryTest {
 
         repository.upsert(oppdatertListe)
 
-        repository.get(deltakerliste.id) shouldBe oppdatertListe
+        repository.get(deltakerliste.id).getOrNull() shouldBe oppdatertListe
     }
 
     @Test
@@ -57,7 +57,7 @@ class DeltakerlisteRepositoryTest {
 
         repository.delete(deltakerliste.id)
 
-        repository.get(deltakerliste.id) shouldBe null
+        repository.get(deltakerliste.id).getOrNull() shouldBe null
     }
 
     @Test
@@ -67,10 +67,10 @@ class DeltakerlisteRepositoryTest {
         TestRepository.insert(arrangor)
         repository.upsert(deltakerliste)
 
-        val deltakerlisteMedArrangor = repository.get(deltakerliste.id)
+        val deltakerlisteMedArrangor = repository.get(deltakerliste.id).getOrThrow()
 
         deltakerlisteMedArrangor shouldNotBe null
-        deltakerlisteMedArrangor?.navn shouldBe deltakerliste.navn
-        deltakerlisteMedArrangor?.arrangor?.navn shouldBe arrangor.navn
+        deltakerlisteMedArrangor.navn shouldBe deltakerliste.navn
+        deltakerlisteMedArrangor.arrangor.navn shouldBe arrangor.navn
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumerTest.kt
@@ -40,7 +40,7 @@ class DeltakerlisteConsumerTest {
                 objectMapper.writeValueAsString(TestData.lagDeltakerlisteDto(arrangor, deltakerliste)),
             )
 
-            repository.get(deltakerliste.id) shouldBe deltakerliste
+            repository.get(deltakerliste.id).getOrThrow() shouldBe deltakerliste
         }
     }
 
@@ -61,7 +61,7 @@ class DeltakerlisteConsumerTest {
                 objectMapper.writeValueAsString(TestData.lagDeltakerlisteDto(arrangor, oppdatertDeltakerliste)),
             )
 
-            repository.get(deltakerliste.id) shouldBe oppdatertDeltakerliste
+            repository.get(deltakerliste.id).getOrThrow() shouldBe oppdatertDeltakerliste
         }
     }
 
@@ -77,7 +77,7 @@ class DeltakerlisteConsumerTest {
         runBlocking {
             consumer.consumeDeltakerliste(deltakerliste.id, null)
 
-            repository.get(deltakerliste.id) shouldBe null
+            repository.get(deltakerliste.id).getOrNull() shouldBe null
         }
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/navenhet/NavEnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/navenhet/NavEnhetServiceTest.kt
@@ -29,7 +29,7 @@ class NavEnhetServiceTest {
     fun `hentEllerOpprettNavEnhet - navenhet finnes i db - henter fra db`() {
         val navEnhet = TestData.lagNavEnhet()
         repository.upsert(navEnhet)
-        val navEnhetService = NavEnhetService(repository, mockk<AmtPersonServiceClient>())
+        val navEnhetService = NavEnhetService(repository, mockk())
 
         runBlocking {
             val navEnhetFraDb = navEnhetService.hentEllerOpprettNavEnhet(navEnhet.enhetsnummer)

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -71,7 +71,7 @@ object TestData {
     fun lagDeltaker(
         id: UUID = UUID.randomUUID(),
         personident: String = randomIdent(),
-        deltakerlisteId: UUID = UUID.randomUUID(),
+        deltakerliste: Deltakerliste = lagDeltakerliste(),
         startdato: LocalDate? = LocalDate.now().minusMonths(3),
         sluttdato: LocalDate? = LocalDate.now().minusDays(1),
         dagerPerUke: Float? = 5F,
@@ -86,7 +86,7 @@ object TestData {
     ) = Deltaker(
         id,
         personident,
-        deltakerlisteId,
+        deltakerliste,
         startdato,
         sluttdato,
         dagerPerUke,
@@ -99,6 +99,11 @@ object TestData {
         sistEndret,
         opprettet,
     )
+
+    fun lagDeltakerStatus(
+        statusType: DeltakerStatus.Type,
+        aarsak: DeltakerStatus.Aarsak? = null,
+    ) = lagDeltakerStatus(type = statusType, aarsak = aarsak)
 
     fun lagDeltakerStatus(
         id: UUID = UUID.randomUUID(),

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
@@ -70,12 +70,11 @@ object TestRepository {
 
     fun insert(
         deltaker: Deltaker,
-        deltakerliste: Deltakerliste = TestData.lagDeltakerliste(id = deltaker.deltakerlisteId),
     ) = Database.query { session ->
         try {
-            insert(deltakerliste)
+            insert(deltaker.deltakerliste)
         } catch (e: Exception) {
-            log.warn("Deltakerliste med id ${deltakerliste.id} er allerede opprettet")
+            log.warn("Deltakerliste med id ${deltaker.deltakerliste.id} er allerede opprettet")
         }
 
         val sql = """
@@ -92,7 +91,7 @@ object TestRepository {
         val parameters = mapOf(
             "id" to deltaker.id,
             "personident" to deltaker.personident,
-            "deltakerlisteId" to deltaker.deltakerlisteId,
+            "deltakerlisteId" to deltaker.deltakerliste.id,
             "startdato" to deltaker.startdato,
             "sluttdato" to deltaker.sluttdato,
             "dagerPerUke" to deltaker.dagerPerUke,


### PR DESCRIPTION
Jeg tenker at hvis vi nesten alltid trenger Deltakerlisten og Arrangør når vi skal hente Deltaker, så er de like gjerne en del av modellen. Også synes jeg det er litt ryddigere og flytte dtoer/responser så langt ut mot apiet som mulig, det gjør det litt lettere å forholde seg til hva man får fra `DeltakerService` i hvertfall, spesielt i testene.