### PR TITLE
Inputvalidering og sanitering for kladd

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApi.kt
@@ -61,7 +61,7 @@ fun Routing.registerPameldingApi(
 
         post("/pamelding/{deltakerId}/kladd") {
             val navIdent = getNavIdent()
-            val request = call.receive<KladdRequest>()
+            val request = call.receive<KladdRequest>().sanitize()
 
             val deltaker = deltakerService.get(UUID.fromString(call.parameters["deltakerId"])).getOrThrow()
             request.valider(deltaker)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/EndreInnholdRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/EndreInnholdRequest.kt
@@ -1,6 +1,6 @@
 package no.nav.amt.deltaker.bff.deltaker.api.model
 
-import no.nav.amt.deltaker.bff.deltaker.api.utils.validerInnhold
+import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDeltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 
 data class EndreInnholdRequest(
@@ -10,6 +10,6 @@ data class EndreInnholdRequest(
         require(!opprinneligDeltaker.harSluttet()) {
             "Kan ikke endre innhold for deltaker som har sluttet"
         }
-        validerInnhold(innhold, opprinneligDeltaker.deltakerliste.tiltak.innhold)
+        validerDeltakelsesinnhold(innhold, opprinneligDeltaker.deltakerliste.tiltak.innhold)
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/KladdRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/KladdRequest.kt
@@ -1,10 +1,14 @@
 package no.nav.amt.deltaker.bff.deltaker.api.model
 
-import no.nav.amt.deltaker.bff.deltaker.api.utils.validerBakgrunnsinformasjon
-import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDagerPerUke
-import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDeltakelsesProsent
-import no.nav.amt.deltaker.bff.deltaker.api.utils.validerInnhold
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MAX_ANNET_INNHOLD_LENGDE
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MAX_BAKGRUNNSINFORMASJON_LENGDE
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MAX_DAGER_PER_UKE
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MAX_DELTAKELSESPROSENT
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MIN_DAGER_PER_UKE
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MIN_DELTAKELSESPROSENT
+import no.nav.amt.deltaker.bff.deltaker.api.utils.validerKladdInnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
+import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.annetInnholdselement
 
 data class KladdRequest(
     val innhold: List<InnholdDto>,
@@ -12,10 +16,48 @@ data class KladdRequest(
     val deltakelsesprosent: Int?,
     val dagerPerUke: Int?,
 ) {
-    fun valider(deltaker: Deltaker) {
-        validerBakgrunnsinformasjon(bakgrunnsinformasjon)
-        validerDeltakelsesProsent(deltakelsesprosent)
-        validerDagerPerUke(dagerPerUke)
-        validerInnhold(innhold, deltaker.deltakerliste.tiltak.innhold)
+    /**
+     * Kladd må støtte autolagring, dvs. at vi kan ikke feile selv om påmeldingsskjemaet er uferdig eller inneholder
+     * feil. Så vi tillater mer innhold i fritekstfelt enn normalt og avkorter innholdet etter et hvis punkt,
+     * og setteer deltakelsemengde til nærmeste gyldige verdi.
+     *
+     * Disse reglene gjelder kun for kladd.
+     */
+    fun sanitize() = KladdRequest(
+        innhold = innhold.sanitize(),
+        bakgrunnsinformasjon = bakgrunnsinformasjon?.sanitize(),
+        deltakelsesprosent = deltakelsesprosent?.clamp(MIN_DELTAKELSESPROSENT, MAX_DELTAKELSESPROSENT),
+        dagerPerUke = dagerPerUke?.clamp(MIN_DAGER_PER_UKE, MAX_DAGER_PER_UKE),
+    )
+
+    fun valider(deltaker: Deltaker) = validerKladdInnhold(this.innhold, deltaker.deltakerliste.tiltak.innhold)
+}
+
+private fun String.sanitize(): String {
+    val gyldigLengde = 0..<MAX_BAKGRUNNSINFORMASJON_LENGDE * 2
+
+    return if (this.length > gyldigLengde.max()) {
+        this.slice(gyldigLengde)
+    } else {
+        this
     }
+}
+
+private fun List<InnholdDto>.sanitize() = this.map {
+    val gyldigLengde = 0..<MAX_ANNET_INNHOLD_LENGDE * 2
+    if (
+        it.innholdskode == annetInnholdselement.innholdskode &&
+        it.beskrivelse != null &&
+        it.beskrivelse.length > gyldigLengde.max()
+    ) {
+        it.copy(beskrivelse = it.beskrivelse.slice(gyldigLengde))
+    } else {
+        it
+    }
+}
+
+private fun Int.clamp(min: Int, max: Int) = when {
+    this < min -> min
+    this > max -> max
+    else -> this
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/PameldingUtenGodkjenningRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/PameldingUtenGodkjenningRequest.kt
@@ -3,7 +3,7 @@ package no.nav.amt.deltaker.bff.deltaker.api.model
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerBakgrunnsinformasjon
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDagerPerUke
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDeltakelsesProsent
-import no.nav.amt.deltaker.bff.deltaker.api.utils.validerInnhold
+import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDeltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 
 data class PameldingUtenGodkjenningRequest(
@@ -16,6 +16,6 @@ data class PameldingUtenGodkjenningRequest(
         validerBakgrunnsinformasjon(bakgrunnsinformasjon)
         validerDeltakelsesProsent(deltakelsesprosent)
         validerDagerPerUke(dagerPerUke)
-        validerInnhold(innhold, deltaker.deltakerliste.tiltak.innhold)
+        validerDeltakelsesinnhold(innhold, deltaker.deltakerliste.tiltak.innhold)
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/UtkastRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/UtkastRequest.kt
@@ -3,7 +3,7 @@ package no.nav.amt.deltaker.bff.deltaker.api.model
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerBakgrunnsinformasjon
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDagerPerUke
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDeltakelsesProsent
-import no.nav.amt.deltaker.bff.deltaker.api.utils.validerInnhold
+import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDeltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 
 data class UtkastRequest(
@@ -16,6 +16,6 @@ data class UtkastRequest(
         validerBakgrunnsinformasjon(bakgrunnsinformasjon)
         validerDeltakelsesProsent(deltakelsesprosent)
         validerDagerPerUke(dagerPerUke)
-        validerInnhold(innhold, deltaker.deltakerliste.tiltak.innhold)
+        validerDeltakelsesinnhold(innhold, deltaker.deltakerliste.tiltak.innhold)
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
@@ -174,7 +174,11 @@ class DeltakerApiTest {
         } returns oppdatertDeltakerResponse
 
         setUpTestApplication()
-        client.post("/deltaker/${deltaker.id}/innhold") { postRequest(innholdRequest) }.apply {
+        client.post("/deltaker/${deltaker.id}/innhold") {
+            postRequest(
+                EndreInnholdRequest(listOf(InnholdDto(deltaker.innhold[0].innholdskode, null))),
+            )
+        }.apply {
             TestCase.assertEquals(HttpStatusCode.OK, status)
             TestCase.assertEquals(
                 objectMapper.writeValueAsString(oppdatertDeltakerResponse.toDeltakerResponse()),

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/KladdRequestTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/KladdRequestTest.kt
@@ -1,0 +1,91 @@
+package no.nav.amt.deltaker.bff.deltaker.api.model
+
+import io.kotest.matchers.shouldBe
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MAX_ANNET_INNHOLD_LENGDE
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MAX_BAKGRUNNSINFORMASJON_LENGDE
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MAX_DAGER_PER_UKE
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MAX_DELTAKELSESPROSENT
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MIN_DAGER_PER_UKE
+import no.nav.amt.deltaker.bff.deltaker.api.utils.MIN_DELTAKELSESPROSENT
+import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.annetInnholdselement
+import no.nav.amt.deltaker.bff.utils.data.TestData.input
+import org.junit.Test
+
+class KladdRequestTest {
+    @Test
+    fun `sanitize - bakgrunnsinformasjon er lengre enn max - avkorter teksten`() {
+        val request = KladdRequest(
+            innhold = emptyList(),
+            bakgrunnsinformasjon = input(MAX_BAKGRUNNSINFORMASJON_LENGDE * 2 + 1),
+            deltakelsesprosent = null,
+            dagerPerUke = null,
+        )
+
+        request.sanitize().bakgrunnsinformasjon!!.length shouldBe MAX_BAKGRUNNSINFORMASJON_LENGDE * 2
+    }
+
+    @Test
+    fun `sanitize - annet beskrivelse er lengre enn max - avkorter teksten`() {
+        val request = KladdRequest(
+            innhold = listOf(
+                InnholdDto(
+                    innholdskode = annetInnholdselement.innholdskode,
+                    beskrivelse = input(MAX_ANNET_INNHOLD_LENGDE * 2 + 1),
+                ),
+            ),
+            bakgrunnsinformasjon = null,
+            deltakelsesprosent = null,
+            dagerPerUke = null,
+        )
+
+        request.sanitize().innhold[0].beskrivelse!!.length shouldBe MAX_ANNET_INNHOLD_LENGDE * 2
+    }
+
+    @Test
+    fun `sanitize - deltakelsesprosent er større enn max - runder ned til nærmest gyldige verdi`() {
+        val request = KladdRequest(
+            innhold = emptyList(),
+            bakgrunnsinformasjon = null,
+            deltakelsesprosent = MAX_DELTAKELSESPROSENT + 1,
+            dagerPerUke = null,
+        )
+
+        request.sanitize().deltakelsesprosent shouldBe MAX_DELTAKELSESPROSENT
+    }
+
+    @Test
+    fun `sanitize - deltakelsesprosent er mindre enn min - runder opp til nærmest gyldige verdi`() {
+        val request = KladdRequest(
+            innhold = emptyList(),
+            bakgrunnsinformasjon = null,
+            deltakelsesprosent = MIN_DELTAKELSESPROSENT - 1,
+            dagerPerUke = null,
+        )
+
+        request.sanitize().deltakelsesprosent shouldBe MIN_DELTAKELSESPROSENT
+    }
+
+    @Test
+    fun `sanitize - dagerPerUke er større enn max - runder ned til nærmest gyldige verdi`() {
+        val request = KladdRequest(
+            innhold = emptyList(),
+            bakgrunnsinformasjon = null,
+            deltakelsesprosent = null,
+            dagerPerUke = MAX_DAGER_PER_UKE + 1,
+        )
+
+        request.sanitize().dagerPerUke shouldBe MAX_DAGER_PER_UKE
+    }
+
+    @Test
+    fun `sanitize - dagerPerUke er mindre enn min - runder opp til nærmest gyldige verdi`() {
+        val request = KladdRequest(
+            innhold = emptyList(),
+            bakgrunnsinformasjon = null,
+            deltakelsesprosent = null,
+            dagerPerUke = MIN_DAGER_PER_UKE - 1,
+        )
+
+        request.sanitize().dagerPerUke shouldBe MIN_DAGER_PER_UKE
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/utils/InputvalideringTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/utils/InputvalideringTest.kt
@@ -6,6 +6,7 @@ import no.nav.amt.deltaker.bff.deltaker.api.model.InnholdDto
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.Innholdselement
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.annetInnholdselement
 import no.nav.amt.deltaker.bff.utils.data.TestData
+import no.nav.amt.deltaker.bff.utils.data.TestData.input
 import org.junit.Test
 
 class InputvalideringTest {
@@ -81,7 +82,7 @@ class InputvalideringTest {
     }
 
     @Test
-    fun testValiderInnhold() {
+    fun testValiderDeltakelsesinnhold() {
         val tiltaksinnhold = TestData.lagDeltakerRegistreringInnhold(
             innholdselementer = listOf(
                 Innholdselement("Type", "type"),
@@ -90,27 +91,93 @@ class InputvalideringTest {
         )
 
         shouldThrow<IllegalArgumentException> {
-            validerInnhold(emptyList(), null)
+            validerDeltakelsesinnhold(listOf(InnholdDto("type", null)), null)
         }
         shouldThrow<IllegalArgumentException> {
-            validerInnhold(listOf(InnholdDto("foo", null)), tiltaksinnhold)
+            validerDeltakelsesinnhold(
+                listOf(InnholdDto("type", null)),
+                TestData.lagDeltakerRegistreringInnhold(innholdselementer = emptyList()),
+            )
         }
         shouldThrow<IllegalArgumentException> {
-            validerInnhold(listOf(InnholdDto(annetInnholdselement.innholdskode, null)), tiltaksinnhold)
+            validerDeltakelsesinnhold(emptyList(), tiltaksinnhold)
         }
         shouldNotThrow<IllegalArgumentException> {
-            validerInnhold(
+            validerDeltakelsesinnhold(emptyList(), null)
+        }
+        shouldThrow<IllegalArgumentException> {
+            validerDeltakelsesinnhold(listOf(InnholdDto("foo", null)), tiltaksinnhold)
+        }
+        shouldThrow<IllegalArgumentException> {
+            validerDeltakelsesinnhold(listOf(InnholdDto(annetInnholdselement.innholdskode, null)), tiltaksinnhold)
+        }
+        shouldThrow<IllegalArgumentException> {
+            validerDeltakelsesinnhold(listOf(InnholdDto(annetInnholdselement.innholdskode, "")), tiltaksinnhold)
+        }
+        shouldNotThrow<IllegalArgumentException> {
+            validerDeltakelsesinnhold(
                 listOf(InnholdDto(annetInnholdselement.innholdskode, "annet innhold må ha beskrivelse")),
                 tiltaksinnhold,
             )
         }
         shouldNotThrow<IllegalArgumentException> {
-            validerInnhold(listOf(InnholdDto("type", null)), tiltaksinnhold)
+            validerDeltakelsesinnhold(listOf(InnholdDto("type", null)), tiltaksinnhold)
         }
         shouldThrow<IllegalArgumentException> {
-            validerInnhold(listOf(InnholdDto("type", "andre typer enn annet skal ikke ha beskrivelse")), tiltaksinnhold)
+            validerDeltakelsesinnhold(
+                listOf(InnholdDto("type", "andre typer enn annet skal ikke ha beskrivelse")),
+                tiltaksinnhold,
+            )
         }
     }
 
-    private fun input(n: Int) = (1..n).map { ('a'..'z').random() }.joinToString("")
+    @Test
+    fun testValiderKladdInnhold() {
+        val tiltaksinnhold = TestData.lagDeltakerRegistreringInnhold(
+            innholdselementer = listOf(
+                Innholdselement("Type", "type"),
+                annetInnholdselement,
+            ),
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            validerKladdInnhold(listOf(InnholdDto("type", null)), null)
+        }
+        shouldThrow<IllegalArgumentException> {
+            validerKladdInnhold(
+                listOf(InnholdDto("type", null)),
+                TestData.lagDeltakerRegistreringInnhold(innholdselementer = emptyList()),
+            )
+        }
+        shouldNotThrow<IllegalArgumentException> {
+            validerKladdInnhold(emptyList(), tiltaksinnhold)
+        }
+        shouldNotThrow<IllegalArgumentException> {
+            validerKladdInnhold(emptyList(), null)
+        }
+        shouldThrow<IllegalArgumentException> {
+            validerKladdInnhold(listOf(InnholdDto("foo", null)), tiltaksinnhold)
+        }
+        shouldNotThrow<IllegalArgumentException> {
+            validerKladdInnhold(listOf(InnholdDto(annetInnholdselement.innholdskode, null)), tiltaksinnhold)
+        }
+        shouldNotThrow<IllegalArgumentException> {
+            validerKladdInnhold(listOf(InnholdDto(annetInnholdselement.innholdskode, "")), tiltaksinnhold)
+        }
+        shouldNotThrow<IllegalArgumentException> {
+            validerKladdInnhold(
+                listOf(InnholdDto(annetInnholdselement.innholdskode, "annet innhold må ha beskrivelse")),
+                tiltaksinnhold,
+            )
+        }
+        shouldNotThrow<IllegalArgumentException> {
+            validerKladdInnhold(listOf(InnholdDto("type", null)), tiltaksinnhold)
+        }
+        shouldThrow<IllegalArgumentException> {
+            validerKladdInnhold(
+                listOf(InnholdDto("type", "andre typer enn annet skal ikke ha beskrivelse")),
+                tiltaksinnhold,
+            )
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepositoryTest.kt
@@ -26,6 +26,7 @@ class DeltakerlisteRepositoryTest {
         val arrangor = TestData.lagArrangor()
         val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
         TestRepository.insert(arrangor)
+        TestRepository.insert(deltakerliste.tiltak)
 
         repository.upsert(deltakerliste)
 
@@ -37,6 +38,7 @@ class DeltakerlisteRepositoryTest {
         val arrangor = TestData.lagArrangor()
         val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
         TestRepository.insert(arrangor)
+        TestRepository.insert(deltakerliste.tiltak)
 
         repository.upsert(deltakerliste)
 
@@ -52,6 +54,7 @@ class DeltakerlisteRepositoryTest {
         val arrangor = TestData.lagArrangor()
         val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
         TestRepository.insert(arrangor)
+        TestRepository.insert(deltakerliste.tiltak)
 
         repository.upsert(deltakerliste)
 
@@ -65,6 +68,7 @@ class DeltakerlisteRepositoryTest {
         val arrangor = TestData.lagArrangor()
         val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
         TestRepository.insert(arrangor)
+        TestRepository.insert(deltakerliste.tiltak)
         repository.upsert(deltakerliste)
 
         val deltakerlisteMedArrangor = repository.get(deltakerliste.id).getOrThrow()

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -35,6 +35,8 @@ object TestData {
 
     fun randomOrgnr() = (900_000_000..999_999_998).random().toString()
 
+    fun input(n: Int) = (1..n).map { ('a'..'z').random() }.joinToString("")
+
     fun lagArrangor(
         id: UUID = UUID.randomUUID(),
         navn: String = "Arrangor 1",
@@ -99,7 +101,7 @@ object TestData {
         dagerPerUke: Float? = 5F,
         deltakelsesprosent: Float? = 100F,
         bakgrunnsinformasjon: String? = "Søkes inn fordi...",
-        innhold: List<Innhold> = emptyList(),
+        innhold: List<Innhold> = deltakerliste.tiltak.innhold?.innholdselementer?.map { it.toInnhold() } ?: emptyList(),
         status: DeltakerStatus = lagDeltakerStatus(type = DeltakerStatus.Type.HAR_SLUTTET),
         vedtaksinformasjon: Deltaker.Vedtaksinformasjon = lagVedtaksinformasjon(
             fattet = LocalDateTime.now().minusMonths(4),
@@ -286,11 +288,17 @@ object TestData {
         navn: String = "Veileder Veiledersen",
     ) = NavAnsatt(id, navIdent, navn)
 
+    private val navEnhetCache = mutableMapOf<String, NavEnhet>()
+
     fun lagNavEnhet(
         id: UUID = UUID.randomUUID(),
         enhetsnummer: String = randomEnhetsnummer(),
         navn: String = "NAV Testheim",
-    ) = NavEnhet(id, enhetsnummer, navn)
+    ): NavEnhet {
+        val enhet = navEnhetCache[enhetsnummer] ?: NavEnhet(id, enhetsnummer, navn)
+        navEnhetCache[enhetsnummer] = enhet
+        return enhet
+    }
 
     fun lagEndringsmelding(
         id: UUID = UUID.randomUUID(),

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
@@ -65,29 +65,33 @@ object TestRepository {
     }
 
     fun insert(tiltakstype: Tiltakstype) = Database.query {
-        val sql = """
-            INSERT INTO tiltakstype(
-                id, 
-                navn, 
-                type, 
-                innhold)
-            VALUES (:id,
-                    :navn,
-                    :type,
-                    :innhold)
-        """.trimIndent()
+        try {
+            val sql = """
+                INSERT INTO tiltakstype(
+                    id, 
+                    navn, 
+                    type, 
+                    innhold)
+                VALUES (:id,
+                        :navn,
+                        :type,
+                        :innhold)
+            """.trimIndent()
 
-        it.update(
-            queryOf(
-                sql,
-                mapOf(
-                    "id" to tiltakstype.id,
-                    "navn" to tiltakstype.navn,
-                    "type" to tiltakstype.type.name,
-                    "innhold" to toPGObject(tiltakstype.innhold),
+            it.update(
+                queryOf(
+                    sql,
+                    mapOf(
+                        "id" to tiltakstype.id,
+                        "navn" to tiltakstype.navn,
+                        "type" to tiltakstype.type.name,
+                        "innhold" to toPGObject(tiltakstype.innhold),
+                    ),
                 ),
-            ),
-        )
+            )
+        } catch (e: Exception) {
+            log.warn("Tiltakstype ${tiltakstype.navn} er allerede opprettet")
+        }
     }
 
     fun insert(deltakerliste: Deltakerliste) {


### PR DESCRIPTION
Kladd må støtte autolagring, dvs. at vi kan ikke feile selv om påmeldingsskjemaet er uferdig eller inneholder feil. Så vi tillater mer innhold i fritekstfelt enn normalt og avkorter innholdet etter et hvis punkt, og setteer deltakelsemengde til nærmeste gyldige verdi.