### PR TITLE
bruker overordnet arrangør for arrangørnavn

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponse.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponse.kt
@@ -9,6 +9,7 @@ import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.Innholdselement
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.annetInnholdselement
 import no.nav.amt.deltaker.bff.navansatt.NavAnsatt
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhet
+import no.nav.amt.deltaker.bff.utils.toTitleCase
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -73,7 +74,7 @@ fun Deltaker.toDeltakerResponse(
             deltakerlisteId = deltakerliste.id,
             deltakerlisteNavn = deltakerliste.navn,
             tiltakstype = deltakerliste.tiltak.type,
-            arrangorNavn = deltakerliste.arrangor.navn,
+            arrangorNavn = deltakerliste.arrangor.getArrangorNavn(),
             oppstartstype = deltakerliste.getOppstartstype(),
             startdato = deltakerliste.startDato,
             sluttdato = deltakerliste.sluttDato,
@@ -94,6 +95,16 @@ fun Deltaker.toDeltakerResponse(
         sistEndret = sistEndret,
         sistEndretAv = ansatte[sistEndretAv]?.navn ?: sistEndretAv,
     )
+}
+
+fun Deltakerliste.Arrangor.getArrangorNavn(): String {
+    val arrangorNavnForDeltakerliste =
+        if (overordnetArrangorNavn.isNullOrEmpty() || overordnetArrangorNavn == "Ukjent Virksomhet") {
+            arrangor.navn
+        } else {
+            overordnetArrangorNavn
+        }
+    return toTitleCase(arrangorNavnForDeltakerliste)
 }
 
 fun fulltInnhold(valgtInnhold: List<Innhold>, innholdselementer: List<Innholdselement>): List<Innhold> {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -50,11 +50,16 @@ class DeltakerRepository {
             startDato = row.localDate("start_dato"),
             sluttDato = row.localDate("slutt_dato"),
             oppstart = Deltakerliste.Oppstartstype.valueOf(row.string("oppstart")),
-            arrangor = Arrangor(
-                id = row.uuid("arrangor_id"),
-                navn = row.string("arrangor_navn"),
-                organisasjonsnummer = row.string("organisasjonsnummer"),
-                overordnetArrangorId = row.uuidOrNull("overordnet_arrangor_id"),
+            arrangor = Deltakerliste.Arrangor(
+                arrangor = Arrangor(
+                    id = row.uuid("arrangor_id"),
+                    navn = row.string("arrangor_navn"),
+                    organisasjonsnummer = row.string("a.organisasjonsnummer"),
+                    overordnetArrangorId = row.uuidOrNull("a.overordnet_arrangor_id"),
+                ),
+                overordnetArrangorNavn = row.uuidOrNull("a.overordnet_arrangor_id")?.let {
+                    row.string("overordnet_arrangor_navn")
+                },
             ),
         ),
         startdato = row.localDateOrNull("d.startdato"),
@@ -339,8 +344,9 @@ class DeltakerRepository {
                    dl.slutt_dato,
                    dl.oppstart,
                    a.navn             AS arrangor_navn,
-                   organisasjonsnummer,
-                   overordnet_arrangor_id,
+                   a.organisasjonsnummer as "a.organisasjonsnummer",
+                   a.overordnet_arrangor_id as "a.overordnet_arrangor_id",
+                   oa.navn  AS overordnet_arrangor_navn,
                    v.fattet as "v.fattet",
                    v.fattet_av_nav as "v.fattet_av_nav",
                    v.created_at as "v.opprettet",
@@ -358,6 +364,7 @@ class DeltakerRepository {
                 join deltakerliste dl on d.deltakerliste_id = dl.id
                 join arrangor a on a.id = dl.arrangor_id
                 join tiltakstype t on t.type = dl.tiltakstype
+                left join arrangor oa on oa.id = a.overordnet_arrangor_id
                 left join vedtak v on d.id = v.deltaker_id and v.gyldig_til is null
                 $where
       """

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/Deltakerliste.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/Deltakerliste.kt
@@ -1,6 +1,5 @@
 package no.nav.amt.deltaker.bff.deltakerliste
 
-import no.nav.amt.deltaker.bff.arrangor.Arrangor
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.Tiltakstype
 import java.time.LocalDate
 import java.util.UUID
@@ -15,6 +14,11 @@ data class Deltakerliste(
     val oppstart: Oppstartstype?,
     val arrangor: Arrangor,
 ) {
+    data class Arrangor(
+        val arrangor: no.nav.amt.deltaker.bff.arrangor.Arrangor,
+        val overordnetArrangorNavn: String?,
+    )
+
     enum class Oppstartstype {
         LOPENDE,
         FELLES,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepository.kt
@@ -26,11 +26,16 @@ class DeltakerlisteRepository {
         startDato = row.localDate("start_dato"),
         sluttDato = row.localDate("slutt_dato"),
         oppstart = Deltakerliste.Oppstartstype.valueOf(row.string("oppstart")),
-        arrangor = Arrangor(
-            id = row.uuid("arrangor_id"),
-            navn = row.string("arrangor_navn"),
-            organisasjonsnummer = row.string("organisasjonsnummer"),
-            overordnetArrangorId = row.uuidOrNull("overordnet_arrangor_id"),
+        arrangor = Deltakerliste.Arrangor(
+            arrangor = Arrangor(
+                id = row.uuid("arrangor_id"),
+                navn = row.string("arrangor_navn"),
+                organisasjonsnummer = row.string("a.organisasjonsnummer"),
+                overordnetArrangorId = row.uuidOrNull("a.overordnet_arrangor_id"),
+            ),
+            overordnetArrangorNavn = row.uuidOrNull("a.overordnet_arrangor_id")?.let {
+                row.string("overordnet_arrangor_navn")
+            },
         ),
     )
 
@@ -74,7 +79,7 @@ class DeltakerlisteRepository {
                     "id" to deltakerliste.id,
                     "navn" to deltakerliste.navn,
                     "status" to deltakerliste.status.name,
-                    "arrangor_id" to deltakerliste.arrangor.id,
+                    "arrangor_id" to deltakerliste.arrangor.arrangor.id,
                     "tiltaksnavn" to deltakerliste.tiltak.navn,
                     "tiltakstype" to deltakerliste.tiltak.type.name,
                     "start_dato" to deltakerliste.startDato,
@@ -110,14 +115,16 @@ class DeltakerlisteRepository {
                        slutt_dato,
                        oppstart,
                        a.navn             AS arrangor_navn,
-                       organisasjonsnummer,
-                       overordnet_arrangor_id,
+                       a.organisasjonsnummer as "a.organisasjonsnummer",
+                       a.overordnet_arrangor_id as "a.overordnet_arrangor_id",
+                       oa.navn as overordnet_arrangor_navn,
                        t.id as "t.id",
                        t.navn as "t.navn",
                        t.type as "t.type",
                        t.innhold as "t.innhold"
                 FROM deltakerliste d
                          JOIN arrangor a ON a.id = d.arrangor_id
+                         LEFT JOIN arrangor oa ON oa.id = a.overordnet_arrangor_id
                          LEFT JOIN tiltakstype t ON d.tiltakstype = t.type
                 WHERE d.id = :id
             """.trimIndent(),

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteDto.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteDto.kt
@@ -48,6 +48,9 @@ data class DeltakerlisteDto(
         startDato = this.startDato,
         sluttDato = this.sluttDato,
         oppstart = this.oppstart,
-        arrangor = arrangor,
+        arrangor = Deltakerliste.Arrangor(
+            arrangor = arrangor,
+            overordnetArrangorNavn = null,
+        ),
     )
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/utils/StringUtils.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/utils/StringUtils.kt
@@ -1,0 +1,27 @@
+package no.nav.amt.deltaker.bff.utils
+
+val FORKORTELSER_MED_STORE_BOKSTAVER = listOf(
+    "as",
+    "a/s",
+)
+
+val ORD_MED_SMA_BOKSTAVER = listOf(
+    "i",
+    "og",
+)
+
+fun toTitleCase(tekst: String): String {
+    return tekst.lowercase().split(Regex("(?<=\\s|-|')")).joinToString("") {
+        when (it.trim()) {
+            in FORKORTELSER_MED_STORE_BOKSTAVER -> {
+                it.uppercase()
+            }
+            in ORD_MED_SMA_BOKSTAVER -> {
+                it
+            }
+            else -> {
+                it.replaceFirstChar(Char::uppercaseChar)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/PameldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/PameldingServiceTest.kt
@@ -73,12 +73,13 @@ class PameldingServiceTest {
 
     @Test
     fun `opprettKladd - deltaker finnes ikke - oppretter ny deltaker`() {
-        val arrangor = TestData.lagArrangor()
-        val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
+        val overordnetArrangor = TestData.lagArrangor()
+        val arrangor = TestData.lagArrangor(overordnetArrangorId = overordnetArrangor.id)
+        val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor, overordnetArrangor = overordnetArrangor)
         val navBruker = TestData.lagNavBruker()
         val opprettetAv = TestData.randomNavIdent()
         val opprettetAvEnhet = TestData.randomEnhetsnummer()
-        TestRepository.insert(deltakerliste)
+        TestRepository.insert(deltakerliste, overordnetArrangor)
         mockPameldingService(navBruker = navBruker)
 
         runBlocking {
@@ -93,7 +94,8 @@ class PameldingServiceTest {
             deltaker.deltakerliste.id shouldBe deltakerliste.id
             deltaker.deltakerliste.navn shouldBe deltakerliste.navn
             deltaker.deltakerliste.tiltak.type shouldBe deltakerliste.tiltak.type
-            deltaker.deltakerliste.arrangor.navn shouldBe arrangor.navn
+            deltaker.deltakerliste.arrangor.arrangor shouldBe arrangor
+            deltaker.deltakerliste.arrangor.overordnetArrangorNavn shouldBe overordnetArrangor.navn
             deltaker.deltakerliste.getOppstartstype() shouldBe deltakerliste.getOppstartstype()
             deltaker.status.type shouldBe DeltakerStatus.Type.KLADD
             deltaker.startdato shouldBe null

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponseTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponseTest.kt
@@ -1,9 +1,13 @@
 package no.nav.amt.deltaker.bff.deltaker.api.model
 
 import io.kotest.matchers.shouldBe
+import no.nav.amt.deltaker.bff.arrangor.Arrangor
+import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.Innholdselement
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.annetInnholdselement
+import no.nav.amt.deltaker.bff.utils.data.TestData
 import org.junit.Test
+import java.util.UUID
 
 class DeltakerResponseTest {
 
@@ -49,5 +53,35 @@ class DeltakerResponseTest {
                 else -> it.valgt shouldBe false
             }
         }
+    }
+
+    @Test
+    fun `getArrangorNavn - har ikke overordnet arrangor - bruker arrangornavn i titlecase`() {
+        val arrangor = Deltakerliste.Arrangor(
+            arrangor = Arrangor(
+                id = UUID.randomUUID(),
+                navn = "DIN ARRANGØR AS",
+                organisasjonsnummer = TestData.randomOrgnr(),
+                overordnetArrangorId = null,
+            ),
+            overordnetArrangorNavn = null,
+        )
+
+        arrangor.getArrangorNavn() shouldBe "Din Arrangør AS"
+    }
+
+    @Test
+    fun `getArrangorNavn - har overordnet arrangor - bruker overordnet arrangornavn i titlecase`() {
+        val arrangor = Deltakerliste.Arrangor(
+            arrangor = Arrangor(
+                id = UUID.randomUUID(),
+                navn = "DIN ARRANGØR AS",
+                organisasjonsnummer = TestData.randomOrgnr(),
+                overordnetArrangorId = UUID.randomUUID(),
+            ),
+            overordnetArrangorNavn = "TILTAK OG MULIGHETER",
+        )
+
+        arrangor.getArrangorNavn() shouldBe "Tiltak og Muligheter"
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteRepositoryTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldNotBe
 import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import java.time.LocalDate
@@ -21,11 +22,17 @@ class DeltakerlisteRepositoryTest {
         }
     }
 
+    @Before
+    fun cleanDatabase() {
+        TestRepository.cleanDatabase()
+    }
+
     @Test
     fun `upsert - ny deltakerliste - inserter`() {
         val arrangor = TestData.lagArrangor()
         val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
         TestRepository.insert(arrangor)
+        TestRepository.insert(tiltakstype = deltakerliste.tiltak)
 
         repository.upsert(deltakerliste)
 
@@ -37,6 +44,7 @@ class DeltakerlisteRepositoryTest {
         val arrangor = TestData.lagArrangor()
         val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
         TestRepository.insert(arrangor)
+        TestRepository.insert(tiltakstype = deltakerliste.tiltak)
 
         repository.upsert(deltakerliste)
 
@@ -52,6 +60,7 @@ class DeltakerlisteRepositoryTest {
         val arrangor = TestData.lagArrangor()
         val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
         TestRepository.insert(arrangor)
+        TestRepository.insert(tiltakstype = deltakerliste.tiltak)
 
         repository.upsert(deltakerliste)
 
@@ -62,15 +71,19 @@ class DeltakerlisteRepositoryTest {
 
     @Test
     fun `get - deltakerliste og arrangor finnes - henter deltakerliste`() {
-        val arrangor = TestData.lagArrangor()
-        val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
+        val overordnetArrangor = TestData.lagArrangor()
+        val arrangor = TestData.lagArrangor(overordnetArrangorId = overordnetArrangor.id)
+        val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor, overordnetArrangor = overordnetArrangor)
+        TestRepository.insert(overordnetArrangor)
         TestRepository.insert(arrangor)
+        TestRepository.insert(tiltakstype = deltakerliste.tiltak)
         repository.upsert(deltakerliste)
 
         val deltakerlisteMedArrangor = repository.get(deltakerliste.id).getOrThrow()
 
         deltakerlisteMedArrangor shouldNotBe null
         deltakerlisteMedArrangor.navn shouldBe deltakerliste.navn
-        deltakerlisteMedArrangor.arrangor.navn shouldBe arrangor.navn
+        deltakerlisteMedArrangor.arrangor.arrangor.navn shouldBe arrangor.navn
+        deltakerlisteMedArrangor.arrangor.overordnetArrangorNavn shouldBe overordnetArrangor.navn
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumerTest.kt
@@ -11,6 +11,7 @@ import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository
 import no.nav.amt.deltaker.bff.utils.mockAmtArrangorClient
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import java.time.LocalDate
@@ -30,10 +31,16 @@ class DeltakerlisteConsumerTest {
         }
     }
 
+    @Before
+    fun cleanDatabase() {
+        TestRepository.cleanDatabase()
+    }
+
     @Test
     fun `consumeDeltakerliste - ny liste og arrangor - lagrer deltakerliste`() {
         val arrangor = TestData.lagArrangor()
         val deltakerliste = TestData.lagDeltakerliste(arrangor = arrangor)
+        TestRepository.insert(tiltakstype = deltakerliste.tiltak)
         val arrangorService = ArrangorService(ArrangorRepository(), mockAmtArrangorClient(arrangor))
         val consumer = DeltakerlisteConsumer(repository, arrangorService, tiltakstypeRepository)
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -44,14 +44,15 @@ object TestData {
 
     fun lagDeltakerliste(
         id: UUID = UUID.randomUUID(),
-        arrangor: Arrangor = lagArrangor(),
+        overordnetArrangor: Arrangor? = null,
+        arrangor: Arrangor = lagArrangor(overordnetArrangorId = overordnetArrangor?.id),
         tiltak: Tiltakstype = lagTiltakstype(),
         navn: String = "Test Deltakerliste ${tiltak.type}",
         status: Deltakerliste.Status = Deltakerliste.Status.GJENNOMFORES,
         startDato: LocalDate = LocalDate.now().minusMonths(1),
         sluttDato: LocalDate? = LocalDate.now().plusYears(1),
         oppstart: Deltakerliste.Oppstartstype? = finnOppstartstype(tiltak.type),
-    ) = Deltakerliste(id, tiltak, navn, status, startDato, sluttDato, oppstart, arrangor)
+    ) = Deltakerliste(id, tiltak, navn, status, startDato, sluttDato, oppstart, Deltakerliste.Arrangor(arrangor, overordnetArrangor?.navn))
 
     val tiltakstypeCache = mutableMapOf<Tiltak.Type, Tiltakstype>()
 


### PR DESCRIPTION
https://trello.com/c/YFj2DUdI/1379-bytte-fra-underenhet-til-hovedenhet

Jeg aner ikke hvor heldig det egentlig er å joine tabellen med seg selv på denne måten, men det funker hvertfall 😅 Og siden dette er data vi må ha tilgjengelig for hver eneste respons vi sender så tenkte jeg det kunne være greit å få det inn i den spørringen vi allerede bruker. 

Det er også en utfordring her at testene går i beina på hverandre når vi går mot en live database. Noen tester har fungert fordi de kjører sammen med andre som oppretter det de trenger, mens andre tester kunne feile når de ble kjørt sammen fordi de prøver å opprette de samme tiltakstypene som er opprettet av andre fra før. Det er derfor jeg har måttet gjøre endringer på testene som ikke egentlig er relatert til endringen som er gjort her. 