### PR TITLE
henter oppdatert nav-enhet

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
@@ -132,12 +132,13 @@ fun Application.module() {
     val tilgangskontrollService = TilgangskontrollService(poaoTilgangCachedClient)
     val deltakerRepository = DeltakerRepository()
 
-    val deltakerService = DeltakerService(deltakerRepository, amtDeltakerClient)
+    val deltakerService = DeltakerService(deltakerRepository, amtDeltakerClient, navEnhetService)
 
     val pameldingService = PameldingService(
         deltakerService = deltakerService,
         navBrukerService = navBrukerService,
         amtDeltakerClient = amtDeltakerClient,
+        navEnhetService = navEnhetService,
     )
 
     val endringsmeldingRepository = EndringsmeldingRepository()

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
@@ -9,12 +9,14 @@ import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltaker.model.Deltakeroppdatering
 import no.nav.amt.deltaker.bff.deltaker.model.Pamelding
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class DeltakerService(
     private val deltakerRepository: DeltakerRepository,
     private val amtDeltakerClient: AmtDeltakerClient,
+    private val navEnhetService: NavEnhetService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -28,6 +30,7 @@ class DeltakerService(
         endretAv: String,
         endretAvEnhet: String,
     ): Deltaker {
+        navEnhetService.opprettEllerOppdaterNavEnhet(endretAvEnhet)
         val oppdatertDeltaker = when (endring) {
             is DeltakerEndring.Endring.EndreBakgrunnsinformasjon -> endreDeltaker(deltaker) {
                 amtDeltakerClient.endreBakgrunnsinformasjon(

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/PameldingService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/PameldingService.kt
@@ -7,6 +7,7 @@ import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltaker.model.Kladd
 import no.nav.amt.deltaker.bff.deltaker.model.Utkast
 import no.nav.amt.deltaker.bff.deltaker.navbruker.NavBrukerService
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
@@ -14,6 +15,7 @@ class PameldingService(
     private val deltakerService: DeltakerService,
     private val navBrukerService: NavBrukerService,
     private val amtDeltakerClient: AmtDeltakerClient,
+    private val navEnhetService: NavEnhetService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -55,6 +57,7 @@ class PameldingService(
     }
 
     suspend fun upsertUtkast(utkast: Utkast) {
+        navEnhetService.opprettEllerOppdaterNavEnhet(utkast.pamelding.endretAvEnhet)
         amtDeltakerClient.utkast(utkast)
     }
 
@@ -73,6 +76,7 @@ class PameldingService(
         avbruttAvEnhet: String,
         avbruttAv: String,
     ) {
+        navEnhetService.opprettEllerOppdaterNavEnhet(avbruttAvEnhet)
         amtDeltakerClient.avbrytUtkast(deltakerId, avbruttAv, avbruttAvEnhet)
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/navenhet/NavEnhetDbo.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/navenhet/NavEnhetDbo.kt
@@ -1,0 +1,19 @@
+package no.nav.amt.deltaker.bff.navansatt.navenhet
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class NavEnhetDbo(
+    val id: UUID,
+    val enhetsnummer: String,
+    val navn: String,
+    val sistEndret: LocalDateTime,
+) {
+    fun toNavEnhet(): NavEnhet {
+        return NavEnhet(
+            id = id,
+            enhetsnummer = enhetsnummer,
+            navn = navn,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/navenhet/NavEnhetRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/navenhet/NavEnhetRepository.kt
@@ -7,13 +7,14 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 class NavEnhetRepository {
-    private fun rowMapper(row: Row) = NavEnhet(
+    private fun rowMapper(row: Row) = NavEnhetDbo(
         id = row.uuid("id"),
         enhetsnummer = row.string("nav_enhet_nummer"),
         navn = row.string("navn"),
+        sistEndret = row.localDateTime("modified_at"),
     )
 
-    fun upsert(navEnhet: NavEnhet): NavEnhet {
+    fun upsert(navEnhet: NavEnhet): NavEnhetDbo {
         val sql =
             """
             INSERT INTO nav_enhet(id, nav_enhet_nummer, navn, modified_at)
@@ -40,7 +41,7 @@ class NavEnhetRepository {
         } ?: throw RuntimeException("Noe gikk galt ved lagring av nav-enhet")
     }
 
-    fun get(enhetsnummer: String): NavEnhet? {
+    fun get(enhetsnummer: String): NavEnhetDbo? {
         return Database.query {
             val query = queryOf(
                 """select * from nav_enhet where nav_enhet_nummer = :nav_enhet_nummer""",
@@ -51,7 +52,7 @@ class NavEnhetRepository {
         }
     }
 
-    fun get(id: UUID): NavEnhet? {
+    fun get(id: UUID): NavEnhetDbo? {
         return Database.query {
             val query = queryOf(
                 """select * from nav_enhet where id = :id""",

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerServiceTest.kt
@@ -7,12 +7,15 @@ import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltaker.model.Deltakeroppdatering
 import no.nav.amt.deltaker.bff.deltaker.model.Innhold
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetRepository
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import no.nav.amt.deltaker.bff.utils.MockResponseHandler
 import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository
 import no.nav.amt.deltaker.bff.utils.data.endre
 import no.nav.amt.deltaker.bff.utils.mockAmtDeltakerClient
+import no.nav.amt.deltaker.bff.utils.mockAmtPersonServiceClient
 import org.junit.Test
 import java.time.LocalDate
 
@@ -21,7 +24,8 @@ class DeltakerServiceTest {
         SingletonPostgresContainer.start()
     }
 
-    private val service = DeltakerService(DeltakerRepository(), mockAmtDeltakerClient())
+    private val navEnhetService = NavEnhetService(NavEnhetRepository(), mockAmtPersonServiceClient())
+    private val service = DeltakerService(DeltakerRepository(), mockAmtDeltakerClient(), navEnhetService)
 
     @Test
     fun `oppdaterDeltaker(endring) - kaller client og returnerer deltaker`(): Unit = runBlocking {

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/PameldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/PameldingServiceTest.kt
@@ -9,11 +9,14 @@ import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerVedVedtak
 import no.nav.amt.deltaker.bff.deltaker.navbruker.NavBrukerRepository
 import no.nav.amt.deltaker.bff.deltaker.navbruker.NavBrukerService
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetRepository
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import no.nav.amt.deltaker.bff.utils.MockResponseHandler
 import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository
 import no.nav.amt.deltaker.bff.utils.mockAmtDeltakerClient
+import no.nav.amt.deltaker.bff.utils.mockAmtPersonServiceClient
 import no.nav.amt.deltaker.bff.utils.shouldBeCloseTo
 import org.junit.BeforeClass
 import org.junit.Test
@@ -23,15 +26,18 @@ import kotlin.test.assertFailsWith
 
 class PameldingServiceTest {
     companion object {
+        private val navEnhetService = NavEnhetService(NavEnhetRepository(), mockAmtPersonServiceClient())
         private val deltakerService = DeltakerService(
             deltakerRepository = DeltakerRepository(),
-            mockAmtDeltakerClient(),
+            amtDeltakerClient = mockAmtDeltakerClient(),
+            navEnhetService = navEnhetService,
         )
 
         private var pameldingService = PameldingService(
             deltakerService = deltakerService,
             navBrukerService = NavBrukerService(NavBrukerRepository()),
             amtDeltakerClient = mockAmtDeltakerClient(),
+            navEnhetService = navEnhetService,
         )
 
         @JvmStatic

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerServiceTest.kt
@@ -6,18 +6,22 @@ import no.nav.amt.deltaker.bff.deltaker.DeltakerService
 import no.nav.amt.deltaker.bff.deltaker.db.DeltakerRepository
 import no.nav.amt.deltaker.bff.deltaker.db.sammenlignDeltakere
 import no.nav.amt.deltaker.bff.deltaker.model.sammenlignVedtak
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetRepository
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import no.nav.amt.deltaker.bff.utils.MockResponseHandler
 import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository
 import no.nav.amt.deltaker.bff.utils.mockAmtDeltakerClient
+import no.nav.amt.deltaker.bff.utils.mockAmtPersonServiceClient
 import org.junit.Assert.assertThrows
 import org.junit.BeforeClass
 import org.junit.Test
 
 class InnbyggerServiceTest {
     private val amtDeltakerClient = mockAmtDeltakerClient()
-    private val deltakerService = DeltakerService(DeltakerRepository(), amtDeltakerClient)
+    private val navEnhetService = NavEnhetService(NavEnhetRepository(), mockAmtPersonServiceClient())
+    private val deltakerService = DeltakerService(DeltakerRepository(), amtDeltakerClient, navEnhetService)
     private val innbyggerService = InnbyggerService(amtDeltakerClient, deltakerService)
 
     companion object {

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/navenhet/NavEnhetServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/navansatt/navenhet/NavEnhetServiceTest.kt
@@ -8,10 +8,12 @@ import no.nav.amt.deltaker.bff.navansatt.AmtPersonServiceClient
 import no.nav.amt.deltaker.bff.navansatt.NavEnhetDto
 import no.nav.amt.deltaker.bff.utils.SingletonPostgresContainer
 import no.nav.amt.deltaker.bff.utils.data.TestData
+import no.nav.amt.deltaker.bff.utils.data.TestRepository
 import no.nav.amt.deltaker.bff.utils.mockAzureAdClient
 import no.nav.amt.deltaker.bff.utils.mockHttpClient
 import org.junit.BeforeClass
 import org.junit.Test
+import java.time.LocalDateTime
 
 class NavEnhetServiceTest {
     companion object {
@@ -26,19 +28,19 @@ class NavEnhetServiceTest {
     }
 
     @Test
-    fun `hentEllerOpprettNavEnhet - navenhet finnes i db - henter fra db`() {
+    fun `opprettEllerOppdaterNavEnhet - navenhet finnes i db - henter fra db`() {
         val navEnhet = TestData.lagNavEnhet()
         repository.upsert(navEnhet)
         val navEnhetService = NavEnhetService(repository, mockk())
 
         runBlocking {
-            val navEnhetFraDb = navEnhetService.hentEllerOpprettNavEnhet(navEnhet.enhetsnummer)
+            val navEnhetFraDb = navEnhetService.opprettEllerOppdaterNavEnhet(navEnhet.enhetsnummer)
             navEnhetFraDb shouldBe navEnhet
         }
     }
 
     @Test
-    fun `hentEllerOpprettNavEnhet - navenhet finnes ikke i db - henter fra personservice og lagrer`() {
+    fun `opprettEllerOppdaterNavEnhet - navenhet finnes ikke i db - henter fra personservice og lagrer`() {
         val navEnhetResponse = TestData.lagNavEnhet()
         val httpClient =
             mockHttpClient(
@@ -53,10 +55,42 @@ class NavEnhetServiceTest {
         val navEnhetService = NavEnhetService(repository, amtPersonServiceClient)
 
         runBlocking {
-            val navEnhet = navEnhetService.hentEllerOpprettNavEnhet(navEnhetResponse.enhetsnummer)
+            val navEnhet = navEnhetService.opprettEllerOppdaterNavEnhet(navEnhetResponse.enhetsnummer)
 
             navEnhet shouldBe navEnhetResponse
-            repository.get(navEnhetResponse.enhetsnummer) shouldBe navEnhetResponse
+            repository.get(navEnhetResponse.enhetsnummer)?.toNavEnhet() shouldBe navEnhetResponse
+        }
+    }
+
+    @Test
+    fun `opprettEllerOppdaterNavEnhet - utdatert navenhet finnes i db - henter fra personservice og oppdaterer`() {
+        val utdatertNavEnhet = TestData.lagNavEnhet()
+        TestRepository.insert(
+            NavEnhetDbo(
+                id = utdatertNavEnhet.id,
+                enhetsnummer = utdatertNavEnhet.enhetsnummer,
+                navn = utdatertNavEnhet.navn,
+                sistEndret = LocalDateTime.now().minusMonths(2),
+            ),
+        )
+        val navEnhetResponse = TestData.lagNavEnhet(id = utdatertNavEnhet.id, utdatertNavEnhet.enhetsnummer, "Oppdatert navn")
+        val httpClient =
+            mockHttpClient(
+                objectMapper.writeValueAsString(NavEnhetDto(navEnhetResponse.id, navEnhetResponse.enhetsnummer, navEnhetResponse.navn)),
+            )
+        val amtPersonServiceClient = AmtPersonServiceClient(
+            baseUrl = "http://amt-person-service",
+            scope = "scope",
+            httpClient = httpClient,
+            azureAdTokenClient = mockAzureAdClient(),
+        )
+        val navEnhetService = NavEnhetService(repository, amtPersonServiceClient)
+
+        runBlocking {
+            val navEnhet = navEnhetService.opprettEllerOppdaterNavEnhet(navEnhetResponse.enhetsnummer)
+
+            navEnhet shouldBe navEnhetResponse
+            repository.get(navEnhetResponse.enhetsnummer)?.toNavEnhet() shouldBe navEnhetResponse
         }
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/MockHttpClient.kt
@@ -23,9 +23,13 @@ import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.Deltakeroppdatering
 import no.nav.amt.deltaker.bff.deltaker.model.Vedtak
+import no.nav.amt.deltaker.bff.navansatt.AmtPersonServiceClient
+import no.nav.amt.deltaker.bff.navansatt.NavEnhetDto
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhet
 import no.nav.amt.deltaker.bff.utils.data.TestData
 
 const val AMT_DELTAKER_URL = "http://amt-deltaker"
+const val AMT_PERSON_SERVICE_URL = "http://amt-person-service"
 
 fun mockHttpClient(defaultResponse: Any? = null): HttpClient {
     val mockEngine = MockEngine {
@@ -67,6 +71,20 @@ fun mockAmtDeltakerClient() = AmtDeltakerClient(
     httpClient = mockHttpClient(),
     azureAdTokenClient = mockAzureAdClient(),
 )
+
+fun mockAmtPersonServiceClient(navEnhet: NavEnhet = TestData.lagNavEnhet()): AmtPersonServiceClient {
+    val navEnhetDto = NavEnhetDto(
+        id = navEnhet.id,
+        navn = navEnhet.navn,
+        enhetId = navEnhet.enhetsnummer,
+    )
+    return AmtPersonServiceClient(
+        baseUrl = AMT_PERSON_SERVICE_URL,
+        scope = "amt.personservice.scope",
+        httpClient = mockHttpClient(objectMapper.writeValueAsString(navEnhetDto)),
+        azureAdTokenClient = mockAzureAdClient(),
+    )
+}
 
 fun mockAzureAdClient() = AzureAdTokenClient(
     azureAdTokenUrl = "http://azure",

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
@@ -13,7 +13,7 @@ import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.Tiltakstype
 import no.nav.amt.deltaker.bff.endringsmelding.Endringsmelding
 import no.nav.amt.deltaker.bff.navansatt.NavAnsatt
-import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhet
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetDbo
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.util.UUID
@@ -267,7 +267,7 @@ object TestRepository {
         it.update(queryOf(sql, params))
     }
 
-    fun insert(navEnhet: NavEnhet) = Database.query {
+    fun insert(navEnhetDbo: NavEnhetDbo) = Database.query {
         val sql =
             """
             insert into nav_enhet(id, nav_enhet_nummer, navn, modified_at)
@@ -276,10 +276,10 @@ object TestRepository {
             """.trimIndent()
 
         val params = mapOf(
-            "id" to navEnhet.id,
-            "nav_enhet_nummer" to navEnhet.enhetsnummer,
-            "navn" to navEnhet.navn,
-            "modified_at" to LocalDateTime.now(),
+            "id" to navEnhetDbo.id,
+            "nav_enhet_nummer" to navEnhetDbo.enhetsnummer,
+            "navn" to navEnhetDbo.navn,
+            "modified_at" to navEnhetDbo.sistEndret,
         )
 
         it.update(queryOf(sql, params))


### PR DESCRIPTION
https://trello.com/c/PLdGHkaD/1501-oppdaterer-deltaker-bff-nav-enheter

I bff-en er det bare når det fattes vedtak/gjøres endringer at vi har et forhold til enheter. Jeg har derfor lagt på kall for å lagre enheter som veileder jobber på hvis de ikke finnes fra før (dette må ha falt ut på et punkt i oppsplittingen), og å oppdatere enheten hvis den ikke har blitt oppdatert siste måneden. 