### PR TITLE
skal ikke kunne endre deltakelse hvis gjennomføring er avlyst/avbrutt

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
@@ -165,7 +165,9 @@ class DeltakerService(
             )
         }
         deltakerRepository.update(deltakeroppdatering)
-        if (deltakeroppdatering.status.type == DeltakerStatus.Type.FEILREGISTRERT) {
+        if (deltakeroppdatering.status.type == DeltakerStatus.Type.FEILREGISTRERT ||
+            deltakeroppdatering.status.aarsak?.type == DeltakerStatus.Aarsak.Type.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT
+        ) {
             deltakerRepository.settKanIkkeEndres(listOf(deltakeroppdatering.id))
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerServiceTest.kt
@@ -270,4 +270,31 @@ class DeltakerServiceTest {
         deltakerFraDb.status.type shouldBe DeltakerStatus.Type.FEILREGISTRERT
         deltakerFraDb.kanEndres shouldBe false
     }
+
+    @Test
+    fun `oppdaterDeltaker(deltakerOppdatering) - avlyst gjennomforing - setter kan ikke endres`() {
+        val deltaker = TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.VENTER_PA_OPPSTART))
+        TestRepository.insert(deltaker)
+        val deltakeroppdatering = Deltakeroppdatering(
+            id = deltaker.id,
+            startdato = null,
+            sluttdato = null,
+            dagerPerUke = null,
+            deltakelsesprosent = null,
+            bakgrunnsinformasjon = null,
+            innhold = emptyList(),
+            status = TestData.lagDeltakerStatus(
+                type = DeltakerStatus.Type.IKKE_AKTUELL,
+                aarsak = DeltakerStatus.Aarsak.Type.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT,
+            ),
+            historikk = emptyList(),
+        )
+
+        service.oppdaterDeltaker(deltakeroppdatering)
+
+        val deltakerFraDb = service.get(deltaker.id).getOrThrow()
+        deltakerFraDb.status.type shouldBe DeltakerStatus.Type.IKKE_AKTUELL
+        deltakerFraDb.status.aarsak?.type shouldBe DeltakerStatus.Aarsak.Type.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT
+        deltakerFraDb.kanEndres shouldBe false
+    }
 }


### PR DESCRIPTION
https://trello.com/c/xr6yQNgO/1649-skal-ikke-kunne-endre-deltakere-som-er-avsluttet-med-%C3%A5rsak-samarbeidetmedarrangoreneravbrutt