### PR TITLE
Legg til tilgjengeliginnhold for validering ved endring

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponse.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponse.kt
@@ -59,6 +59,7 @@ data class DeltakerResponse(
         val startdato: LocalDate,
         val sluttdato: LocalDate?,
         val status: Deltakerliste.Status,
+        val tilgjengeligInnhold: List<Innholdselement>,
     )
 }
 
@@ -81,6 +82,7 @@ fun Deltaker.toDeltakerResponse(
             startdato = deltakerliste.startDato,
             sluttdato = deltakerliste.sluttDato,
             status = deltakerliste.status,
+            tilgjengeligInnhold = deltakerliste.tiltak.innhold?.innholdselementerMedAnnet ?: emptyList(),
         ),
         status = status,
         startdato = startdato,


### PR DESCRIPTION
Deltaker kan ha innhold som ikke lenger finnes på tiltaket. Frontend må kunne se hvilket innholdselement det gjelder og varsle bruker eller fjerne det ved endring.