### PR TITLE
Serialiser lister av generiske typer med type-info

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/application/plugins/Serialization.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/application/plugins/Serialization.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.deltaker.bff.application.plugins
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -26,3 +27,11 @@ fun ObjectMapper.applicationConfig() {
 }
 
 val objectMapper = jacksonObjectMapper().apply { applicationConfig() }
+
+/**
+ * Inkluderer type informasjon som er definert av @JsonTypeInfo i lister og andre samlinger
+ *
+ * Hvis man bruker `writeValueAsString` på en `List<GeneriskType>` så vil den ikke inkludere `type`.
+ */
+inline fun <reified T> ObjectMapper.writePolymorphicListAsString(value: T): String =
+    this.writerFor(object : TypeReference<T>() {}).writeValueAsString(value)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/db/Database.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/db/Database.kt
@@ -1,9 +1,10 @@
 package no.nav.amt.deltaker.bff.db
 
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.application.plugins.writePolymorphicListAsString
 import org.postgresql.util.PGobject
 
-fun toPGObject(value: Any?) = PGobject().also {
+inline fun <reified T> toPGObject(value: T?) = PGobject().also {
     it.type = "json"
-    it.value = value?.let { v -> objectMapper.writeValueAsString(v) }
+    it.value = value?.let { v -> objectMapper.writePolymorphicListAsString(v) }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApi.kt
@@ -1,15 +1,19 @@
 package no.nav.amt.deltaker.bff.deltaker.api
 
+import io.ktor.http.ContentType
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
 import io.ktor.server.auth.authenticate
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import no.nav.amt.deltaker.bff.application.plugins.getNavAnsattAzureId
 import no.nav.amt.deltaker.bff.application.plugins.getNavIdent
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.application.plugins.writePolymorphicListAsString
 import no.nav.amt.deltaker.bff.auth.TilgangskontrollService
 import no.nav.amt.deltaker.bff.deltaker.DeltakerService
 import no.nav.amt.deltaker.bff.deltaker.amtdistribusjon.AmtDistribusjonClient
@@ -195,7 +199,8 @@ fun Routing.registerDeltakerApi(
 
             val arrangornavn = deltaker.deltakerliste.arrangor.getArrangorNavn()
 
-            call.respond(historikk.toResponse(ansatte, arrangornavn, enheter))
+            val json = objectMapper.writePolymorphicListAsString(historikk.toResponse(ansatte, arrangornavn, enheter))
+            call.respondText(json, ContentType.Application.Json)
         }
 
         post("/forslag/{forslagId}/avvis") {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerApi.kt
@@ -1,13 +1,17 @@
 package no.nav.amt.deltaker.bff.innbygger
 
+import io.ktor.http.ContentType
 import io.ktor.server.application.call
 import io.ktor.server.auth.authenticate
 import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import kotlinx.coroutines.launch
 import no.nav.amt.deltaker.bff.application.plugins.getPersonident
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.application.plugins.writePolymorphicListAsString
 import no.nav.amt.deltaker.bff.auth.TilgangskontrollService
 import no.nav.amt.deltaker.bff.deltaker.DeltakerService
 import no.nav.amt.deltaker.bff.deltaker.api.model.getArrangorNavn
@@ -73,7 +77,8 @@ fun Routing.registerInnbyggerApi(
 
             val arrangornavn = deltaker.deltakerliste.arrangor.getArrangorNavn()
 
-            call.respond(historikk.toResponse(ansatte, arrangornavn, enheter))
+            val json = objectMapper.writePolymorphicListAsString(historikk.toResponse(ansatte, arrangornavn, enheter))
+            call.respondText(json, ContentType.Application.Json)
         }
     }
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/db/DatabaseTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/db/DatabaseTest.kt
@@ -6,7 +6,8 @@ import org.junit.Test
 class DatabaseTest {
     @Test
     fun `toPGObject - value er null - skal skrive null ikke en string`() {
-        val result = toPGObject(null)
+        val value: String? = null
+        val result = toPGObject(value)
         result.isNull shouldBe true
         result.value shouldBe null
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
@@ -20,6 +20,7 @@ import no.nav.amt.deltaker.bff.application.plugins.configureAuthentication
 import no.nav.amt.deltaker.bff.application.plugins.configureRouting
 import no.nav.amt.deltaker.bff.application.plugins.configureSerialization
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.application.plugins.writePolymorphicListAsString
 import no.nav.amt.deltaker.bff.auth.TilgangskontrollService
 import no.nav.amt.deltaker.bff.deltaker.DeltakerService
 import no.nav.amt.deltaker.bff.deltaker.PameldingService
@@ -341,9 +342,11 @@ class DeltakerApiTest {
             every { navAnsattService.hentAnsatteForHistorikk(historikk) } returns ansatte
             client.get("/deltaker/${deltaker.id}/historikk") { noBodyRequest() }.apply {
                 status shouldBe HttpStatusCode.OK
-                bodyAsText() shouldBe objectMapper.writeValueAsString(
+                val res = bodyAsText()
+                val json = objectMapper.writePolymorphicListAsString(
                     historikk.toResponse(ansatte, deltaker.deltakerliste.arrangor.getArrangorNavn(), enheter),
                 )
+                res shouldBe json
             }
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -1,7 +1,10 @@
 package no.nav.amt.deltaker.bff.deltaker.db
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.application.plugins.writePolymorphicListAsString
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.response.KladdResponse
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
@@ -103,6 +106,9 @@ class DeltakerRepositoryTest {
         val deltaker = TestData.leggTilHistorikk(baseDeltaker, 2)
 
         TestRepository.insert(deltaker)
+
+        val json = objectMapper.writePolymorphicListAsString(deltaker.historikk)
+        val historikk = objectMapper.readValue<List<DeltakerHistorikk>>(json)
 
         val vedtak = repository.get(baseDeltaker.id).getOrThrow().fattetVedtak!!
         vedtak.fattet shouldNotBe null

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerApiTest.kt
@@ -19,6 +19,7 @@ import no.nav.amt.deltaker.bff.application.plugins.configureAuthentication
 import no.nav.amt.deltaker.bff.application.plugins.configureRouting
 import no.nav.amt.deltaker.bff.application.plugins.configureSerialization
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.application.plugins.writePolymorphicListAsString
 import no.nav.amt.deltaker.bff.auth.TilgangskontrollService
 import no.nav.amt.deltaker.bff.deltaker.DeltakerService
 import no.nav.amt.deltaker.bff.deltaker.PameldingService
@@ -168,7 +169,7 @@ class InnbyggerApiTest {
             every { navAnsattService.hentAnsatteForHistorikk(historikk) } returns ansatte
             client.get("/innbygger/${deltaker.id}/historikk") { noBodyRequest() }.apply {
                 status shouldBe HttpStatusCode.OK
-                bodyAsText() shouldBe objectMapper.writeValueAsString(
+                bodyAsText() shouldBe objectMapper.writePolymorphicListAsString(
                     historikk.toResponse(ansatte, deltaker.deltakerliste.arrangor.getArrangorNavn(), enheter),
                 )
             }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
@@ -1,7 +1,6 @@
 package no.nav.amt.deltaker.bff.utils.data
 
 import kotliquery.queryOf
-import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.deltaker.bff.arrangor.Arrangor
 import no.nav.amt.deltaker.bff.db.toPGObject
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
@@ -182,7 +181,7 @@ object TestRepository {
             "deltakelsesprosent" to deltaker.deltakelsesprosent,
             "bakgrunnsinformasjon" to deltaker.bakgrunnsinformasjon,
             "innhold" to toPGObject(deltaker.innhold),
-            "historikk" to toPGObject(deltaker.historikk.map { objectMapper.writeValueAsString(it) }),
+            "historikk" to toPGObject(deltaker.historikk),
             "kan_endres" to deltaker.kanEndres,
             "modified_at" to deltaker.sistEndret,
         )


### PR DESCRIPTION
Serialiseringen av lister med sealed classes inkluderte ikke JsonTypeInfo automatisk, så man må enten bruke en egen objectmapper eller gjøre serialiseringen manuelt