### PR TITLE
Ikke deaktiver aktive statuser dersom vi leser inn gamle

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -375,10 +375,11 @@ class DeltakerRepository {
             set gyldig_til = current_timestamp
             where deltaker_id = :deltaker_id 
               and id != :id 
+              and gyldig_fra < :ny_gyldig_fra
               and gyldig_til is null;
             """.trimIndent()
 
-        return queryOf(sql, mapOf("id" to status.id, "deltaker_id" to deltakerId))
+        return queryOf(sql, mapOf("id" to status.id, "deltaker_id" to deltakerId, "ny_gyldig_fra" to status.gyldigFra))
     }
 
     private fun getDeltakerSql(where: String = "") = """

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -271,6 +271,37 @@ class DeltakerRepositoryTest {
         val lagretSistBesokt = TestRepository.getDeltakerSistBesokt(deltaker.id)!!
         lagretSistBesokt shouldBeCloseTo sistBesokt
     }
+
+    @Test
+    fun `upsert - gammel status - skal ikke overskrive nyere status`() {
+        val gammelStatus = TestData.lagDeltakerStatus(
+            type = DeltakerStatus.Type.DELTAR,
+            gyldigFra = LocalDateTime.now().minusMonths(3),
+        )
+
+        val deltaker = TestData.lagDeltaker(status = gammelStatus)
+
+        TestRepository.insert(deltaker)
+
+        val nyStatus = TestData.lagDeltakerStatus(
+            type = DeltakerStatus.Type.HAR_SLUTTET,
+            gyldigFra = LocalDateTime.now().minusMonths(1),
+        )
+
+        repository.upsert(deltaker.copy(status = nyStatus))
+
+        repository
+            .get(deltaker.id)
+            .getOrThrow()
+            .status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
+
+        repository.upsert(deltaker.copy(status = gammelStatus))
+
+        val statuser = repository.getDeltakerStatuser(deltaker.id)
+        statuser.size shouldBe 2
+        statuser.first { it.type == DeltakerStatus.Type.HAR_SLUTTET }.gyldigTil shouldBe null
+        statuser.first { it.type == DeltakerStatus.Type.DELTAR }.gyldigTil shouldNotBe null
+    }
 }
 
 private fun Deltaker.toDeltakeroppdatering() = Deltakeroppdatering(


### PR DESCRIPTION
Vi hadde en feil som gjorde at lesingen av `deltaker-v2` stoppet opp i en stund. Dette hindret ikke veileder fra å gjøre endringer i flaten, og bffen ble oppdatert av responsene fra rest-kallene til amt-deltaker. Når vi da fikk lest inn de feilende meldingene så leste vi også inn gamle statuser, som trigget `deaktiverTidligereStatuser` som deaktiverte nyere statuser 😅 