### PR TITLE
Legger inn støtte for å lagre hele innhold med ledetekst på deltaker

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
@@ -4,6 +4,7 @@ import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.AmtDeltakerClient
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.response.KladdResponse
 import no.nav.amt.deltaker.bff.deltaker.db.DeltakerRepository
 import no.nav.amt.deltaker.bff.deltaker.model.AKTIVE_STATUSER
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
@@ -52,7 +53,10 @@ class DeltakerService(
                     deltakerId = deltaker.id,
                     endretAv = endretAv,
                     endretAvEnhet = endretAvEnhet,
-                    innhold = endring.innhold,
+                    innhold = Deltakelsesinnhold(
+                        ledetekst = endring.ledetekst,
+                        innhold = endring.innhold,
+                    ),
                 )
             }
 
@@ -160,7 +164,7 @@ class DeltakerService(
         endring: Pamelding,
     ): Deltaker {
         val deltaker = opprinneligDeltaker.copy(
-            innhold = endring.innhold,
+            deltakelsesinnhold = endring.deltakelsesinnhold,
             bakgrunnsinformasjon = endring.bakgrunnsinformasjon,
             deltakelsesprosent = endring.deltakelsesprosent,
             dagerPerUke = endring.dagerPerUke,
@@ -220,7 +224,7 @@ fun Deltaker.oppdater(oppdatering: Deltakeroppdatering) = this.copy(
     dagerPerUke = oppdatering.dagerPerUke,
     deltakelsesprosent = oppdatering.deltakelsesprosent,
     bakgrunnsinformasjon = oppdatering.bakgrunnsinformasjon,
-    innhold = oppdatering.innhold,
+    deltakelsesinnhold = oppdatering.deltakelsesinnhold,
     status = oppdatering.status,
     historikk = oppdatering.historikk,
 )

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerV2Consumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerV2Consumer.kt
@@ -77,7 +77,7 @@ data class DeltakerV2Dto(
             dagerPerUke = dagerPerUke,
             deltakelsesprosent = prosentStilling?.toFloat(),
             bakgrunnsinformasjon = bestillingTekst,
-            innhold = innhold?.innhold ?: emptyList(),
+            deltakelsesinnhold = innhold,
             status = DeltakerStatus(
                 id = status.id,
                 type = status.type,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/AmtDeltakerClient.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/AmtDeltakerClient.kt
@@ -25,9 +25,9 @@ import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.request.SluttdatoRequest
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.request.StartdatoRequest
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.request.UtkastRequest
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.response.KladdResponse
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.Deltakeroppdatering
-import no.nav.amt.deltaker.bff.deltaker.model.Innhold
 import no.nav.amt.deltaker.bff.deltaker.model.Utkast
 import no.nav.amt.deltaker.bff.deltaker.model.Vedtak
 import org.slf4j.LoggerFactory
@@ -128,7 +128,7 @@ class AmtDeltakerClient(
         deltakerId: UUID,
         endretAv: String,
         endretAvEnhet: String,
-        innhold: List<Innhold>,
+        innhold: Deltakelsesinnhold,
     ) = postEndring(deltakerId, InnholdRequest(endretAv, endretAvEnhet, innhold), INNHOLD)
 
     suspend fun endreDeltakelsesmengde(
@@ -284,7 +284,7 @@ class AmtDeltakerClient(
 }
 
 private fun Utkast.toRequest() = UtkastRequest(
-    innhold = this.pamelding.innhold,
+    deltakelsesinnhold = this.pamelding.deltakelsesinnhold,
     bakgrunnsinformasjon = this.pamelding.bakgrunnsinformasjon,
     deltakelsesprosent = this.pamelding.deltakelsesprosent,
     dagerPerUke = this.pamelding.dagerPerUke,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/request/DeltakerEndringsrequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/request/DeltakerEndringsrequest.kt
@@ -1,7 +1,7 @@
 package no.nav.amt.deltaker.bff.deltaker.amtdeltaker.request
 
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
-import no.nav.amt.deltaker.bff.deltaker.model.Innhold
 import java.time.LocalDate
 import java.util.UUID
 
@@ -23,7 +23,7 @@ data class BakgrunnsinformasjonRequest(
 data class InnholdRequest(
     override val endretAv: String,
     override val endretAvEnhet: String,
-    val innhold: List<Innhold>,
+    val deltakelsesinnhold: Deltakelsesinnhold,
 ) : DeltakerEndringsrequest
 
 data class DeltakelsesmengdeRequest(

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/request/UtkastRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/request/UtkastRequest.kt
@@ -1,9 +1,9 @@
 package no.nav.amt.deltaker.bff.deltaker.amtdeltaker.request
 
-import no.nav.amt.deltaker.bff.deltaker.model.Innhold
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 
 data class UtkastRequest(
-    val innhold: List<Innhold>,
+    val deltakelsesinnhold: Deltakelsesinnhold,
     val bakgrunnsinformasjon: String?,
     val deltakelsesprosent: Float?,
     val dagerPerUke: Float?,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/response/KladdResponse.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/response/KladdResponse.kt
@@ -1,7 +1,7 @@
 package no.nav.amt.deltaker.bff.deltaker.amtdeltaker.response
 
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
-import no.nav.amt.deltaker.bff.deltaker.model.Innhold
 import no.nav.amt.deltaker.bff.deltaker.navbruker.NavBruker
 import java.time.LocalDate
 import java.util.UUID
@@ -15,6 +15,6 @@ data class KladdResponse(
     val dagerPerUke: Float?,
     val deltakelsesprosent: Float?,
     val bakgrunnsinformasjon: String?,
-    val innhold: List<Innhold>,
+    val deltakelsesinnhold: Deltakelsesinnhold,
     val status: DeltakerStatus,
 )

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApi.kt
@@ -107,7 +107,8 @@ fun Routing.registerDeltakerApi(
         post("/deltaker/{deltakerId}/innhold") {
             val request = call.receive<EndreInnholdRequest>()
             handleEndring(call, request) { deltaker ->
-                DeltakerEndring.Endring.EndreInnhold(finnValgtInnhold(request.innhold, deltaker))
+                // Ledetekst kan ikke endres(enda) så den settes midlertidig til det samme igjen.
+                DeltakerEndring.Endring.EndreInnhold(deltaker.deltakelsesinnhold?.ledetekst, finnValgtInnhold(request.innhold, deltaker))
             }
         }
 

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApi.kt
@@ -25,6 +25,7 @@ import no.nav.amt.deltaker.bff.deltaker.api.model.UtkastRequest
 import no.nav.amt.deltaker.bff.deltaker.api.model.finnValgtInnhold
 import no.nav.amt.deltaker.bff.deltaker.api.model.toDeltakerResponse
 import no.nav.amt.deltaker.bff.deltaker.forslag.ForslagService
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.Kladd
 import no.nav.amt.deltaker.bff.deltaker.model.Pamelding
@@ -82,7 +83,10 @@ fun Routing.registerPameldingApi(
                 kladd = Kladd(
                     opprinneligDeltaker = deltaker,
                     pamelding = Pamelding(
-                        innhold = finnValgtInnhold(request.innhold, deltaker),
+                        deltakelsesinnhold = Deltakelsesinnhold(
+                            deltaker.deltakelsesinnhold?.ledetekst,
+                            finnValgtInnhold(request.innhold, deltaker),
+                        ),
                         bakgrunnsinformasjon = request.bakgrunnsinformasjon,
                         deltakelsesprosent = request.deltakelsesprosent?.toFloat(),
                         dagerPerUke = request.dagerPerUke?.toFloat(),
@@ -111,7 +115,10 @@ fun Routing.registerPameldingApi(
                 Utkast(
                     deltakerId = deltaker.id,
                     pamelding = Pamelding(
-                        innhold = finnValgtInnhold(request.innhold, deltaker),
+                        deltakelsesinnhold = Deltakelsesinnhold(
+                            deltaker.deltakelsesinnhold?.ledetekst,
+                            finnValgtInnhold(request.innhold, deltaker),
+                        ),
                         bakgrunnsinformasjon = request.bakgrunnsinformasjon,
                         deltakelsesprosent = request.deltakelsesprosent?.toFloat(),
                         dagerPerUke = request.dagerPerUke?.toFloat(),
@@ -158,7 +165,10 @@ fun Routing.registerPameldingApi(
                 Utkast(
                     deltakerId = deltaker.id,
                     pamelding = Pamelding(
-                        innhold = finnValgtInnhold(request.innhold, deltaker),
+                        deltakelsesinnhold = Deltakelsesinnhold(
+                            deltaker.deltakerliste.tiltak.innhold?.ledetekst,
+                            finnValgtInnhold(request.innhold, deltaker),
+                        ),
                         bakgrunnsinformasjon = request.bakgrunnsinformasjon,
                         deltakelsesprosent = request.deltakelsesprosent?.toFloat(),
                         dagerPerUke = request.dagerPerUke?.toFloat(),

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponse.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerResponse.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.deltaker.bff.deltaker.api.model
 
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltaker.model.Innhold
@@ -48,7 +49,7 @@ data class DeltakerResponse(
     )
 
     data class DeltakelsesinnholdDto(
-        val ledetekst: String,
+        val ledetekst: String?,
         val innhold: List<Innhold>,
     )
 
@@ -92,12 +93,7 @@ fun Deltaker.toDeltakerResponse(
     dagerPerUke = dagerPerUke,
     deltakelsesprosent = deltakelsesprosent,
     bakgrunnsinformasjon = bakgrunnsinformasjon,
-    deltakelsesinnhold = deltakerliste.tiltak.innhold?.let {
-        DeltakerResponse.DeltakelsesinnholdDto(
-            ledetekst = it.ledetekst,
-            innhold = fulltInnhold(innhold, it.innholdselementerMedAnnet),
-        )
-    },
+    deltakelsesinnhold = deltakelsesinnhold?.toDto(deltakerliste.tiltak.innhold?.innholdselementerMedAnnet),
     vedtaksinformasjon = vedtaksinformasjon?.toDto(ansatte, vedtakSistEndretAvEnhet),
     adresseDelesMedArrangor = adresseDelesMedArrangor(),
     kanEndres = kanEndres,
@@ -105,6 +101,11 @@ fun Deltaker.toDeltakerResponse(
     maxVarighet = maxVarighet?.toMillis(),
     softMaxVarighet = softMaxVarighet?.toMillis(),
     forslag = forslag.map { it.toResponse(deltakerliste.arrangor.getArrangorNavn()) },
+)
+
+fun Deltakelsesinnhold.toDto(tiltaksInnhold: List<Innholdselement>?) = DeltakerResponse.DeltakelsesinnholdDto(
+    ledetekst = ledetekst,
+    innhold = fulltInnhold(innhold, tiltaksInnhold ?: emptyList()),
 )
 
 fun Deltakerliste.Arrangor.getArrangorNavn(): String {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -44,7 +44,7 @@ class DeltakerRepository {
         dagerPerUke = row.floatOrNull("d.dager_per_uke"),
         deltakelsesprosent = row.floatOrNull("d.deltakelsesprosent"),
         bakgrunnsinformasjon = row.stringOrNull("d.bakgrunnsinformasjon"),
-        innhold = objectMapper.readValue(row.string("d.innhold")),
+        deltakelsesinnhold = row.stringOrNull("d.innhold")?.let { objectMapper.readValue(it) },
         status = DeltakerStatus(
             id = row.uuid("ds.id"),
             type = row.string("ds.type").let { DeltakerStatus.Type.valueOf(it) },
@@ -93,7 +93,7 @@ class DeltakerRepository {
             "dagerPerUke" to deltaker.dagerPerUke,
             "deltakelsesprosent" to deltaker.deltakelsesprosent,
             "bakgrunnsinformasjon" to deltaker.bakgrunnsinformasjon,
-            "innhold" to toPGObject(deltaker.innhold),
+            "innhold" to toPGObject(deltaker.deltakelsesinnhold),
             "historikk" to toPGObject(deltaker.historikk),
             "kan_endres" to deltaker.kanEndres,
         )
@@ -273,7 +273,7 @@ class DeltakerRepository {
             "dagerPerUke" to kladd.dagerPerUke,
             "deltakelsesprosent" to kladd.deltakelsesprosent,
             "bakgrunnsinformasjon" to kladd.bakgrunnsinformasjon,
-            "innhold" to toPGObject(kladd.innhold),
+            "innhold" to toPGObject(kladd.deltakelsesinnhold),
         )
 
         it.transaction { tx ->
@@ -309,7 +309,7 @@ class DeltakerRepository {
             "dagerPerUke" to deltaker.dagerPerUke,
             "deltakelsesprosent" to deltaker.deltakelsesprosent,
             "bakgrunnsinformasjon" to deltaker.bakgrunnsinformasjon,
-            "innhold" to toPGObject(deltaker.innhold),
+            "innhold" to toPGObject(deltaker.deltakelsesinnhold),
             "historikk" to toPGObject(deltaker.historikk),
         )
 

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltakelsesinnhold.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltakelsesinnhold.kt
@@ -1,6 +1,13 @@
 package no.nav.amt.deltaker.bff.deltaker.model
 
 data class Deltakelsesinnhold(
-    val ledetekst: String,
+    val ledetekst: String?,
     val innhold: List<Innhold>,
+)
+
+data class Innhold(
+    val tekst: String,
+    val innholdskode: String,
+    val valgt: Boolean,
+    val beskrivelse: String?,
 )

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltaker.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltaker.kt
@@ -18,7 +18,7 @@ data class Deltaker(
     val dagerPerUke: Float?,
     val deltakelsesprosent: Float?,
     val bakgrunnsinformasjon: String?,
-    val innhold: List<Innhold>,
+    val deltakelsesinnhold: Deltakelsesinnhold?,
     val status: DeltakerStatus,
     val historikk: List<DeltakerHistorikk>,
     val kanEndres: Boolean,
@@ -130,10 +130,3 @@ fun years(n: Long) = Duration.of(n * 365, ChronoUnit.DAYS)
 fun months(n: Long) = Duration.of(n * 30, ChronoUnit.DAYS)
 
 fun weeks(n: Long) = Duration.of(n * 7, ChronoUnit.DAYS)
-
-data class Innhold(
-    val tekst: String,
-    val innholdskode: String,
-    val valgt: Boolean,
-    val beskrivelse: String?,
-)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/DeltakerEndring.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/DeltakerEndring.kt
@@ -47,6 +47,7 @@ data class DeltakerEndring(
         ) : Endring()
 
         data class EndreInnhold(
+            val ledetekst: String?,
             val innhold: List<Innhold>,
         ) : Endring()
 

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltakeroppdatering.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltakeroppdatering.kt
@@ -10,7 +10,7 @@ data class Deltakeroppdatering(
     val dagerPerUke: Float?,
     val deltakelsesprosent: Float?,
     val bakgrunnsinformasjon: String?,
-    val innhold: List<Innhold>,
+    val deltakelsesinnhold: Deltakelsesinnhold?,
     val status: DeltakerStatus,
     val historikk: List<DeltakerHistorikk>,
     val forcedUpdate: Boolean? = false,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Pamelding.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Pamelding.kt
@@ -3,7 +3,7 @@ package no.nav.amt.deltaker.bff.deltaker.model
 import java.util.UUID
 
 data class Pamelding(
-    val innhold: List<Innhold>,
+    val deltakelsesinnhold: Deltakelsesinnhold,
     val bakgrunnsinformasjon: String?,
     val deltakelsesprosent: Float?,
     val dagerPerUke: Float?,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/innbygger/model/InnbyggerDeltakerResponse.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/innbygger/model/InnbyggerDeltakerResponse.kt
@@ -41,7 +41,7 @@ data class InnbyggerDeltakerResponse(
     )
 
     data class DeltakelsesinnholdDto(
-        val ledetekst: String,
+        val ledetekst: String?,
         val innhold: List<Innhold>,
     )
 
@@ -78,12 +78,10 @@ fun Deltaker.toInnbyggerDeltakerResponse(
         dagerPerUke = dagerPerUke,
         deltakelsesprosent = deltakelsesprosent,
         bakgrunnsinformasjon = bakgrunnsinformasjon,
-        deltakelsesinnhold = deltakerliste.tiltak.innhold?.let {
-            InnbyggerDeltakerResponse.DeltakelsesinnholdDto(
-                ledetekst = it.ledetekst,
-                innhold = innhold,
-            )
-        },
+        deltakelsesinnhold = InnbyggerDeltakerResponse.DeltakelsesinnholdDto(
+            ledetekst = deltakelsesinnhold?.ledetekst,
+            innhold = deltakelsesinnhold?.innhold ?: emptyList(),
+        ),
         vedtaksinformasjon = vedtaksinformasjon?.toDto(ansatte, vedtakSistEndretAvEnhet),
         adresseDelesMedArrangor = adresseDelesMedArrangor(),
         forslag = forslag.map { it.toResponse(deltakerliste.arrangor.getArrangorNavn()) },

--- a/src/main/resources/db/migration/V33__innhold-drop-notnull.sql
+++ b/src/main/resources/db/migration/V33__innhold-drop-notnull.sql
@@ -1,0 +1,1 @@
+alter table deltaker alter column innhold drop not null;

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.amt.deltaker.bff.deltaker
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.runBlocking
 import no.nav.amt.deltaker.bff.deltaker.db.DeltakerRepository
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
 import no.nav.amt.deltaker.bff.deltaker.model.Deltakeroppdatering
@@ -34,7 +35,7 @@ class DeltakerServiceTest {
 
         val endringer = listOf(
             DeltakerEndring.Endring.EndreBakgrunnsinformasjon("foo"),
-            DeltakerEndring.Endring.EndreInnhold(listOf(Innhold("tekst,", "innholdskode,", true, "beskrivelse"))),
+            DeltakerEndring.Endring.EndreInnhold("ledetekst", listOf(Innhold("tekst,", "innholdskode,", true, "beskrivelse"))),
             DeltakerEndring.Endring.EndreDeltakelsesmengde(deltakelsesprosent = 50F, dagerPerUke = 2F, null),
             DeltakerEndring.Endring.EndreStartdato(startdato = LocalDate.now(), sluttdato = LocalDate.now().plusWeeks(2), null),
             DeltakerEndring.Endring.EndreSluttdato(sluttdato = LocalDate.now(), null),
@@ -86,7 +87,8 @@ class DeltakerServiceTest {
                 }
 
                 is DeltakerEndring.Endring.EndreInnhold -> {
-                    oppdatertDeltaker.innhold shouldBe endring.innhold
+                    oppdatertDeltaker.deltakelsesinnhold!!.innhold shouldBe endring.innhold
+                    oppdatertDeltaker.deltakelsesinnhold!!.ledetekst shouldBe endring.ledetekst
                 }
 
                 is DeltakerEndring.Endring.EndreDeltakelsesmengde -> {
@@ -142,7 +144,7 @@ class DeltakerServiceTest {
             dagerPerUke = null,
             deltakelsesprosent = 100F,
             bakgrunnsinformasjon = "Tekst",
-            innhold = emptyList(),
+            deltakelsesinnhold = null,
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.UTKAST_TIL_PAMELDING),
             historikk = emptyList(),
         )
@@ -166,7 +168,7 @@ class DeltakerServiceTest {
             dagerPerUke = null,
             deltakelsesprosent = 100F,
             bakgrunnsinformasjon = "Tekst",
-            innhold = emptyList(),
+            deltakelsesinnhold = Deltakelsesinnhold("ny ledetekst", listOf(Innhold("", "", true, ""))),
             status = TestData.lagDeltakerStatus(
                 type = DeltakerStatus.Type.HAR_SLUTTET,
                 aarsak = DeltakerStatus.Aarsak.Type.ANNET,
@@ -181,6 +183,8 @@ class DeltakerServiceTest {
         deltakerFraDb.status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
         deltakerFraDb.status.aarsak?.type shouldBe DeltakerStatus.Aarsak.Type.ANNET
         deltakerFraDb.status.aarsak?.beskrivelse shouldBe "Oppdatert"
+        deltakerFraDb.deltakelsesinnhold!!.innhold shouldBe deltakeroppdatering.deltakelsesinnhold!!.innhold
+        deltakerFraDb.deltakelsesinnhold!!.ledetekst shouldBe deltakeroppdatering.deltakelsesinnhold!!.ledetekst
         deltakerFraDb.kanEndres shouldBe true
     }
 
@@ -202,7 +206,7 @@ class DeltakerServiceTest {
             dagerPerUke = null,
             deltakelsesprosent = 100F,
             bakgrunnsinformasjon = "Tekst",
-            innhold = emptyList(),
+            deltakelsesinnhold = Deltakelsesinnhold("ny ledetekst", listOf(Innhold("", "", true, ""))),
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.UTKAST_TIL_PAMELDING),
             historikk = emptyList(),
         )
@@ -238,7 +242,7 @@ class DeltakerServiceTest {
             dagerPerUke = null,
             deltakelsesprosent = 100F,
             bakgrunnsinformasjon = "Tekst",
-            innhold = emptyList(),
+            deltakelsesinnhold = null,
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
             historikk = emptyList(),
         )
@@ -263,7 +267,7 @@ class DeltakerServiceTest {
             dagerPerUke = null,
             deltakelsesprosent = null,
             bakgrunnsinformasjon = null,
-            innhold = emptyList(),
+            deltakelsesinnhold = null,
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.FEILREGISTRERT),
             historikk = emptyList(),
         )
@@ -286,7 +290,7 @@ class DeltakerServiceTest {
             dagerPerUke = null,
             deltakelsesprosent = null,
             bakgrunnsinformasjon = null,
-            innhold = emptyList(),
+            deltakelsesinnhold = null,
             status = TestData.lagDeltakerStatus(
                 type = DeltakerStatus.Type.IKKE_AKTUELL,
                 aarsak = DeltakerStatus.Aarsak.Type.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT,

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerV2ConsumerTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerV2ConsumerTest.kt
@@ -4,7 +4,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
-import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import org.junit.Test
@@ -62,9 +61,6 @@ private fun Deltaker.toV2(kilde: DeltakerV2Dto.Kilde) = DeltakerV2Dto(
     sluttdato = sluttdato,
     bestillingTekst = bakgrunnsinformasjon,
     kilde = kilde,
-    innhold = Deltakelsesinnhold(
-        deltakerliste.tiltak.innhold!!.ledetekst,
-        innhold,
-    ),
+    innhold = deltakelsesinnhold,
     historikk = historikk,
 )

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/PameldingServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/PameldingServiceTest.kt
@@ -82,7 +82,7 @@ class PameldingServiceTest {
             deltaker.dagerPerUke shouldBe null
             deltaker.deltakelsesprosent shouldBe null
             deltaker.bakgrunnsinformasjon shouldBe null
-            deltaker.innhold shouldBe emptyList()
+            deltaker.deltakelsesinnhold!!.innhold shouldBe emptyList()
         }
     }
 
@@ -119,7 +119,7 @@ class PameldingServiceTest {
             eksisterendeDeltaker.dagerPerUke shouldBe deltaker.dagerPerUke
             eksisterendeDeltaker.deltakelsesprosent shouldBe deltaker.deltakelsesprosent
             eksisterendeDeltaker.bakgrunnsinformasjon shouldBe deltaker.bakgrunnsinformasjon
-            eksisterendeDeltaker.innhold shouldBe deltaker.innhold
+            eksisterendeDeltaker.deltakelsesinnhold shouldBe deltaker.deltakelsesinnhold
         }
     }
 
@@ -152,7 +152,10 @@ class PameldingServiceTest {
         TestRepository.insert(deltaker)
 
         val forventetDeltaker = deltaker.copy(
-            innhold = listOf(Innhold("nytt innhold", "nytt-innhold", true, null)),
+            deltakelsesinnhold = Deltakelsesinnhold(
+                "Beskrivelse",
+                listOf(Innhold("nytt innhold", "nytt-innhold", true, null)),
+            ),
             bakgrunnsinformasjon = "Noe ny informasjon",
             deltakelsesprosent = 42F,
             dagerPerUke = 3F,
@@ -163,7 +166,7 @@ class PameldingServiceTest {
         val utkast = Utkast(
             deltaker.id,
             Pamelding(
-                forventetDeltaker.innhold,
+                forventetDeltaker.deltakelsesinnhold!!,
                 forventetDeltaker.bakgrunnsinformasjon,
                 forventetDeltaker.deltakelsesprosent,
                 forventetDeltaker.dagerPerUke,
@@ -175,7 +178,7 @@ class PameldingServiceTest {
 
         runBlocking {
             val oppdatertDeltaker = pameldingService.upsertUtkast(utkast)
-            oppdatertDeltaker.innhold shouldBe forventetDeltaker.innhold
+            oppdatertDeltaker.deltakelsesinnhold shouldBe forventetDeltaker.deltakelsesinnhold
             oppdatertDeltaker.bakgrunnsinformasjon shouldBe forventetDeltaker.bakgrunnsinformasjon
             oppdatertDeltaker.deltakelsesprosent shouldBe forventetDeltaker.deltakelsesprosent
             oppdatertDeltaker.dagerPerUke shouldBe forventetDeltaker.dagerPerUke
@@ -206,10 +209,10 @@ fun Deltaker.toDeltakerVedVedtak() = DeltakerVedVedtak(
     dagerPerUke,
     deltakelsesprosent,
     bakgrunnsinformasjon,
-    deltakerliste.tiltak.innhold?.let {
+    deltakelsesinnhold = deltakelsesinnhold?.let {
         Deltakelsesinnhold(
             ledetekst = it.ledetekst,
-            innhold = fulltInnhold(innhold, it.innholdselementerMedAnnet),
+            innhold = fulltInnhold(it.innhold, deltakerliste.tiltak.innhold?.innholdselementerMedAnnet ?: emptyList()),
         )
     },
     status,

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
@@ -45,6 +45,7 @@ import no.nav.amt.deltaker.bff.deltaker.api.model.toDeltakerResponse
 import no.nav.amt.deltaker.bff.deltaker.api.model.toResponse
 import no.nav.amt.deltaker.bff.deltaker.api.utils.postRequest
 import no.nav.amt.deltaker.bff.deltaker.forslag.ForslagService
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerStatus
@@ -185,13 +186,13 @@ class DeltakerApiTest {
             TestData.lagDeltaker(status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.VENTER_PA_OPPSTART))
         val oppdatertDeltaker = deltaker.copy(
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.VENTER_PA_OPPSTART),
-            innhold = finnValgtInnhold(innholdRequest.innhold, deltaker),
+            deltakelsesinnhold = Deltakelsesinnhold("ledetekst", finnValgtInnhold(innholdRequest.innhold, deltaker)),
         )
 
         mockTestApi(deltaker, oppdatertDeltaker) { client, ansatte, enhet ->
             client
                 .post("/deltaker/${deltaker.id}/innhold") {
-                    postRequest(EndreInnholdRequest(listOf(InnholdDto(deltaker.innhold[0].innholdskode, null))))
+                    postRequest(EndreInnholdRequest(listOf(InnholdDto(deltaker.deltakelsesinnhold!!.innhold[0].innholdskode, null))))
                 }.apply {
                     status shouldBe HttpStatusCode.OK
                     bodyAsText() shouldBe objectMapper.writeValueAsString(

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApiTest.kt
@@ -78,13 +78,13 @@ class PameldingApiTest {
         setUpTestApplication()
         client.post("/pamelding") { postRequest(pameldingRequest) }.status shouldBe HttpStatusCode.Forbidden
         client.post("/pamelding/${UUID.randomUUID()}") {
-            postRequest(utkastRequest(deltaker.innhold.toInnholdDto()))
+            postRequest(utkastRequest(deltaker.deltakelsesinnhold!!.innhold.toInnholdDto()))
         }.status shouldBe HttpStatusCode.Forbidden
         client.post("/pamelding/${UUID.randomUUID()}/kladd") { postRequest(kladdRequest) }.status shouldBe HttpStatusCode.Forbidden
         client.post("/pamelding/${UUID.randomUUID()}/utenGodkjenning") {
             postRequest(
                 pameldingUtenGodkjenningRequest(
-                    deltaker.innhold.toInnholdDto(),
+                    deltaker.deltakelsesinnhold!!.innhold.toInnholdDto(),
                 ),
             )
         }.status shouldBe HttpStatusCode.Forbidden
@@ -181,10 +181,12 @@ class PameldingApiTest {
         val (ansatte, enhet) = mockAnsatteOgEnhetForDeltaker(deltaker)
 
         setUpTestApplication()
-        client.post("/pamelding/${deltaker.id}") { postRequest(utkastRequest(deltaker.innhold.toInnholdDto())) }.apply {
-            status shouldBe HttpStatusCode.OK
-            bodyAsText() shouldBe objectMapper.writeValueAsString(deltaker.toDeltakerResponse(ansatte, enhet, true, emptyList()))
-        }
+        client
+            .post("/pamelding/${deltaker.id}") { postRequest(utkastRequest(deltaker.deltakelsesinnhold!!.innhold.toInnholdDto())) }
+            .apply {
+                status shouldBe HttpStatusCode.OK
+                bodyAsText() shouldBe objectMapper.writeValueAsString(deltaker.toDeltakerResponse(ansatte, enhet, true, emptyList()))
+            }
     }
 
     @Test
@@ -208,10 +210,11 @@ class PameldingApiTest {
         val (ansatte, enhet) = mockAnsatteOgEnhetForDeltaker(deltaker)
 
         setUpTestApplication()
-        client.post("/pamelding/${deltaker.id}") { postRequest(utkastRequest(deltaker.innhold.toInnholdDto())) }.apply {
-            status shouldBe HttpStatusCode.OK
-            bodyAsText() shouldBe objectMapper.writeValueAsString(deltaker.toDeltakerResponse(ansatte, enhet, true, emptyList()))
-        }
+        client.post("/pamelding/${deltaker.id}") { postRequest(utkastRequest(deltaker.deltakelsesinnhold!!.innhold.toInnholdDto())) }
+            .apply {
+                status shouldBe HttpStatusCode.OK
+                bodyAsText() shouldBe objectMapper.writeValueAsString(deltaker.toDeltakerResponse(ansatte, enhet, true, emptyList()))
+            }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -311,7 +311,7 @@ private fun Deltaker.toDeltakeroppdatering() = Deltakeroppdatering(
     dagerPerUke,
     deltakelsesprosent,
     bakgrunnsinformasjon,
-    innhold,
+    deltakelsesinnhold,
     status,
     historikk,
 )
@@ -324,7 +324,7 @@ fun sammenlignDeltakere(a: Deltaker, b: Deltaker) {
     a.dagerPerUke shouldBe b.dagerPerUke
     a.deltakelsesprosent shouldBe b.deltakelsesprosent
     a.bakgrunnsinformasjon shouldBe b.bakgrunnsinformasjon
-    a.innhold shouldBe b.innhold
+    a.deltakelsesinnhold shouldBe b.deltakelsesinnhold
     a.historikk shouldBe b.historikk
     a.status.id shouldBe b.status.id
     a.status.type shouldBe b.status.type
@@ -343,7 +343,7 @@ private fun Deltaker.toKladdResponse() = KladdResponse(
     dagerPerUke = dagerPerUke,
     deltakelsesprosent = deltakelsesprosent,
     bakgrunnsinformasjon = bakgrunnsinformasjon,
-    innhold = innhold,
+    deltakelsesinnhold = deltakelsesinnhold!!,
     status = status,
 )
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/MockHttpClient.kt
@@ -141,7 +141,7 @@ object MockResponseHandler {
                     dagerPerUke = deltaker.dagerPerUke,
                     deltakelsesprosent = deltaker.deltakelsesprosent,
                     bakgrunnsinformasjon = deltaker.bakgrunnsinformasjon,
-                    innhold = deltaker.innhold,
+                    deltakelsesinnhold = deltaker.deltakelsesinnhold!!,
                     status = deltaker.status,
                 ),
             )
@@ -208,7 +208,7 @@ fun Deltaker.toDeltakeroppdatering() = Deltakeroppdatering(
     dagerPerUke,
     deltakelsesprosent,
     bakgrunnsinformasjon,
-    innhold,
+    deltakelsesinnhold,
     status,
     historikk,
 )

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -1,6 +1,7 @@
 package no.nav.amt.deltaker.bff.utils.data
 
 import no.nav.amt.deltaker.bff.arrangor.Arrangor
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakelsesinnhold
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerEndring
 import no.nav.amt.deltaker.bff.deltaker.model.DeltakerHistorikk
@@ -147,7 +148,7 @@ object TestData {
             dagerPerUke,
             deltakelsesprosent,
             bakgrunnsinformasjon,
-            innhold,
+            Deltakelsesinnhold("ledetekst", innhold),
             status,
             emptyList(),
             kanEndres,
@@ -374,7 +375,7 @@ fun Deltaker.endre(deltakerEndring: DeltakerEndring): Deltaker {
             deltakelsesprosent = endring.deltakelsesprosent,
         )
 
-        is DeltakerEndring.Endring.EndreInnhold -> this.copy(innhold = endring.innhold)
+        is DeltakerEndring.Endring.EndreInnhold -> this.copy(deltakelsesinnhold = Deltakelsesinnhold(endring.ledetekst, endring.innhold))
         is DeltakerEndring.Endring.EndreSluttarsak ->
             this.copy(status = this.status.copy(aarsak = endring.aarsak.toStatusAarsak()))
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestRepository.kt
@@ -180,7 +180,7 @@ object TestRepository {
             "dagerPerUke" to deltaker.dagerPerUke,
             "deltakelsesprosent" to deltaker.deltakelsesprosent,
             "bakgrunnsinformasjon" to deltaker.bakgrunnsinformasjon,
-            "innhold" to toPGObject(deltaker.innhold),
+            "innhold" to toPGObject(deltaker.deltakelsesinnhold),
             "historikk" to toPGObject(deltaker.historikk),
             "kan_endres" to deltaker.kanEndres,
             "modified_at" to deltaker.sistEndret,


### PR DESCRIPTION
https://github.com/navikt/amt-deltaker/pull/159

Del2 for lagring av ledetekst.
Det er amt-deltaker som setter ledetekst ved opprettelse av kladd, ledeteksten beholdes deretter videre uavhengig av endringer fra valp.
For å kunne endre ledetekst så kreves litt andre type endringer i frontend for å kunne hente "ikke enda godkjent" ledetekst som deretter kan godkjennes samtidig med at man endrer innhold(avklart med Linn at det kan vi ta i neste omgang og legge lengre ned i backloggen)

Innholdet er gjort nullable for å unngå tomme objekter hvor ledetekst og innholdslista er tom(som vil være tilfellet for nye arenadeltakere)

- [x] Endre BFF til å sende og motta ledetekst
- [x] Lagre historikk med ledetekst i BFF
- [ ] Patche bff database(rekonsumer deltakere på deltaker-v2)
- [ ] Tilpasse frontend til å ta imot innhold med ledetekst(/pamelding/{deltakerid}/utenGodkjenning, /historikk, /innhold