### PR TITLE
Setter opp tracing av deploy-pipelinen

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,6 +39,7 @@ jobs:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}
+      telemetry: ${{ steps.docker-build-push.outputs.telemetry }}
 
   deploy-dev:
     name: Deploy application to dev
@@ -55,3 +56,4 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: .nais/nais-dev.yaml
           VAR: image=${{ needs.test-build-and-push.outputs.image }}
+          TELEMETRY: ${{ needs.test-build-and-push.outputs.telemetry }}


### PR DESCRIPTION
Tester tracing i naid deploy-pipeline for å se om vi kan få nyttige metrikker på hvor lang tid det tar fra commit / merge på main til det er deployet og hvor lang tid de forskjellige stegene tar.
Link til tracing-dashboard dukker opp som et GitHub step summary når deploy-jobben er fullført.