### PR TITLE
Revert "må støtte fremtidig status (likt som amt-deltaker) (#322)"

### DIFF
--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -302,31 +302,6 @@ class DeltakerRepositoryTest {
         statuser.first { it.type == DeltakerStatus.Type.HAR_SLUTTET }.gyldigTil shouldBe null
         statuser.first { it.type == DeltakerStatus.Type.DELTAR }.gyldigTil shouldNotBe null
     }
-
-    @Test
-    fun `get - har fremtidig status - henter deltaker med gjeldende status`() {
-        val deltaker = TestData.lagDeltaker(
-            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
-        )
-        TestRepository.insert(deltaker)
-
-        val harSluttetFraDato = LocalDateTime.now().plusDays(2)
-        val oppdatertDeltaker = deltaker.copy(
-            status = TestData.lagDeltakerStatus(
-                type = DeltakerStatus.Type.HAR_SLUTTET,
-                aarsak = DeltakerStatus.Aarsak.Type.UTDANNING,
-                gyldigFra = harSluttetFraDato,
-            ),
-        )
-
-        repository.upsert(oppdatertDeltaker)
-        sammenlignDeltakere(repository.get(deltaker.id).getOrThrow(), deltaker)
-
-        val statuser = repository.getDeltakerStatuser(deltaker.id)
-        statuser.first { it.id == deltaker.status.id }.gyldigTil shouldBe null
-        statuser.first { it.id == oppdatertDeltaker.status.id }.gyldigTil shouldBe null
-        statuser.first { it.id == oppdatertDeltaker.status.id }.gyldigFra shouldBeCloseTo harSluttetFraDato
-    }
 }
 
 private fun Deltaker.toDeltakeroppdatering() = Deltakeroppdatering(


### PR DESCRIPTION
This reverts commit e56de5403a790327a50819c4d4ef5f139c3a6941.

Vi skal ikke støtte fremtidig status i bff-en. Så lenge det publiseres ny melding fra amt-deltaker når statusen endres skal dette gå bra. 