### PR TITLE
unngår å returnere en annen enhet enn den man tror man opprettet

### DIFF
--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/data/TestData.kt
@@ -297,8 +297,9 @@ object TestData {
         navn: String = "NAV Testheim",
     ): NavEnhet {
         val enhet = navEnhetCache[enhetsnummer] ?: NavEnhet(id, enhetsnummer, navn)
-        navEnhetCache[enhetsnummer] = enhet
-        return enhet
+        val nyEnhet = enhet.copy(id = id, navn = navn)
+        navEnhetCache[enhetsnummer] = nyEnhet
+        return nyEnhet
     }
 
     fun lagNavBruker(


### PR DESCRIPTION
Jeg tror kanskje dette er det underliggende problemet med testene. Vi forholder oss ofte til enhetsid (hvertfall når vi henter enheter for historikk), og sånn denne koden var fikk vi tilbake enheter med en annen id enn det vi trodde vi opprettet, og som vi forsøkte å hente opp senere. Da gir det litt mening at vi plutselig ikke hadde definert mockrespons for enheten vi spurte etter, og at det feiler litt tilfeldig avhengig av rekkefølgen testene ble kjørt i. 