### PR TITLE
Fjerne regel om sjekk av 15 dager for deltakere ikke deltatt ved avslutte deltakelse

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/AvsluttDeltakelseRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/AvsluttDeltakelseRequest.kt
@@ -1,7 +1,6 @@
 package no.nav.amt.deltaker.bff.deltaker.api.model
 
 import no.nav.amt.deltaker.bff.deltaker.api.utils.harEndretSluttaarsak
-import no.nav.amt.deltaker.bff.deltaker.api.utils.statusForMindreEnn15DagerSiden
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerAarsaksBeskrivelse
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerBegrunnelse
 import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDeltakerKanEndres

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/AvsluttDeltakelseRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/AvsluttDeltakelseRequest.kt
@@ -36,9 +36,6 @@ data class AvsluttDeltakelseRequest(
             require(deltaker.status.type == DeltakerStatus.Type.DELTAR) {
                 "Deltaker som ikke har status DELTAR må ha deltatt"
             }
-            require(statusForMindreEnn15DagerSiden(deltaker)) {
-                "Deltaker med deltar-status mer enn 15 dager tilbake i tid må ha deltatt"
-            }
         }
         sluttdato?.let { validerSluttdatoForDeltaker(it, deltaker.startdato, deltaker) }
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/DeltakerApiTest.kt
@@ -589,7 +589,7 @@ class DeltakerApiTest {
     }
 
     @Test
-    fun `avslutt - har tilgang, har ikke deltatt, mer enn 15 dager siden - feiler`() = testApplication {
+    fun `avslutt - har tilgang, har ikke deltatt, mer enn 15 dager siden - feiler ikke`() = testApplication {
         setUpTestApplication()
         val deltaker = TestData.lagDeltaker(
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR, gyldigFra = LocalDateTime.now().minusDays(20)),
@@ -609,10 +609,14 @@ class DeltakerApiTest {
             begrunnelse = null,
             forslagId = null,
         )
-        setupMocks(deltaker, oppdatertDeltaker)
+
+        val (ansatte, enhet) = setupMocks(deltaker, oppdatertDeltaker)
 
         client.post("/deltaker/${deltaker.id}/avslutt") { postRequest(avsluttDeltakelseRequestIkkeDeltatt) }.apply {
-            status shouldBe HttpStatusCode.BadRequest
+            status shouldBe HttpStatusCode.OK
+            bodyAsText() shouldBe objectMapper.writeValueAsString(
+                oppdatertDeltaker.toDeltakerResponse(ansatte, enhet, true, emptyList()),
+            )
         }
     }
 


### PR DESCRIPTION


https://trello.com/c/xYBx2BaK/2079-veileder-skal-kunne-godkjenne-forslag-fra-arrang%C3%B8r-som-inneholder-at-bruker-ikke-har-deltatt-selv-etter-15-dager