### PR TITLE
Endrer typen på responsobjekt for vurderinger

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerHistorikkResponse.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/DeltakerHistorikkResponse.kt
@@ -24,6 +24,7 @@ import java.util.UUID
     JsonSubTypes.Type(value = ForslagResponse::class, name = "Forslag"),
     JsonSubTypes.Type(value = EndringFraArrangorResponse::class, name = "EndringFraArrangor"),
     JsonSubTypes.Type(value = ImportertFraArenaResponse::class, name = "ImportertFraArena"),
+    JsonSubTypes.Type(value = VurderingFraArrangorResponse::class, name = "VurderingFraArrangor"),
 )
 sealed interface DeltakerHistorikkResponse
 


### PR DESCRIPTION
https://trello.com/c/ygxVLmVb/2137-nav-veileder-og-bruker-kan-se-tiltaksarrang%C3%B8rs-vurderinger-i-historikk