### PR TITLE
Deaktiver alle andre statuser når man oppdaterer med en ny status

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -443,16 +443,7 @@ class DeltakerRepository {
     }
 
     fun deaktiverUkritiskTidligereStatuserQuery(status: DeltakerStatus, deltakerId: UUID) = Database.query { session ->
-        val sql =
-            """
-            update deltaker_status
-            set gyldig_til = current_timestamp
-            where deltaker_id = :deltaker_id 
-              and id != :id
-              and gyldig_til is null;
-            """.trimIndent()
-
-        val query = queryOf(sql, mapOf("id" to status.id, "deltaker_id" to deltakerId, "ny_gyldig_fra" to status.gyldigFra))
+        val query = queryOf(deaktiverTidligereStatuserSQL, deaktiverTidligereStatuserParams(status, deltakerId))
         session.update(query)
     }
 
@@ -684,10 +675,9 @@ class DeltakerRepository {
         set gyldig_til = current_timestamp
         where deltaker_id = :deltaker_id 
           and id != :id 
-          and gyldig_fra < :ny_gyldig_fra
           and gyldig_til is null;
         """.trimIndent()
 
     private fun deaktiverTidligereStatuserParams(status: DeltakerStatus, deltakerId: UUID) =
-        mapOf("id" to status.id, "deltaker_id" to deltakerId, "ny_gyldig_fra" to status.gyldigFra)
+        mapOf("id" to status.id, "deltaker_id" to deltakerId)
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -309,37 +309,6 @@ class DeltakerRepositoryTest {
     }
 
     @Test
-    fun `upsert - gammel status - skal ikke overskrive nyere status`() {
-        val gammelStatus = TestData.lagDeltakerStatus(
-            type = DeltakerStatus.Type.DELTAR,
-            gyldigFra = LocalDateTime.now().minusMonths(3),
-        )
-
-        val deltaker = TestData.lagDeltaker(status = gammelStatus)
-
-        TestRepository.insert(deltaker)
-
-        val nyStatus = TestData.lagDeltakerStatus(
-            type = DeltakerStatus.Type.HAR_SLUTTET,
-            gyldigFra = LocalDateTime.now().minusMonths(1),
-        )
-
-        repository.upsert(deltaker.copy(status = nyStatus))
-
-        repository
-            .get(deltaker.id)
-            .getOrThrow()
-            .status.type shouldBe DeltakerStatus.Type.HAR_SLUTTET
-
-        repository.upsert(deltaker.copy(status = gammelStatus))
-
-        val statuser = repository.getDeltakerStatuser(deltaker.id)
-        statuser.size shouldBe 2
-        statuser.first { it.type == DeltakerStatus.Type.HAR_SLUTTET }.gyldigTil shouldBe null
-        statuser.first { it.type == DeltakerStatus.Type.DELTAR }.gyldigTil shouldNotBe null
-    }
-
-    @Test
     fun `deaktiverUkritiskTidligereStatuserQuery - skal deaktivere alle andre statuser`() {
         val gammelStatus1 = TestData.lagDeltakerStatus(
             type = DeltakerStatus.Type.DELTAR,


### PR DESCRIPTION
Hvis vi ikke deaktiverer statuser som har en gyldig_fra større enn ny status vil det føre til at deltakere som leses inn fra arena kan få flere aktive statuser. Det skjer fordi status deltar sin gyldig_fra kan settes tilbake i tid, som fører til at den kan få en gyldig_fra før venter på oppstart, f.eks.

Det er uansett en logisk feil hvis vi leser en deltaker med gammel status, det bør ikke skje.