### PR TITLE
Venteliste

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ val postgresVersion = "42.7.5"
 val caffeineVersion = "3.2.0"
 val mockkVersion = "1.14.0"
 val nimbusVersion = "10.2"
-val amtLibVersion = "1.2025.04.08_16.04-e2b9fac2d1ef"
+val amtLibVersion = "1.2025.04.09_11.25-169f8dad347f"
 val unleashVersion = "10.2.2"
 
 dependencies {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
@@ -173,13 +173,6 @@ fun Application.module() {
     val tiltakskoordinatorTilgangRepository = TiltakskoordinatorTilgangRepository()
     val tiltakskoordinatorsDeltakerlisteProducer = TiltakskoordinatorsDeltakerlisteProducer(kafkaProducer)
 
-    val tilgangskontrollService = TilgangskontrollService(
-        poaoTilgangCachedClient,
-        navAnsattService,
-        tiltakskoordinatorTilgangRepository,
-        tiltakskoordinatorsDeltakerlisteProducer,
-    )
-
     val sporbarhetsloggService = SporbarhetsloggService(AuditLoggerImpl())
 
     val deltakerRepository = DeltakerRepository()
@@ -207,6 +200,15 @@ fun Application.module() {
         vurderingService,
         navEnhetService,
         navAnsattService,
+    )
+
+    val tilgangskontrollService = TilgangskontrollService(
+        poaoTilgangCachedClient,
+        navAnsattService,
+        tiltakskoordinatorTilgangRepository,
+        tiltakskoordinatorsDeltakerlisteProducer,
+        tiltakskoordinatorService,
+        deltakerlisteService,
     )
 
     val tiltakstypeRepository = TiltakstypeRepository()

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
@@ -296,7 +296,7 @@ class DeltakerService(
 
     fun getForDeltakerliste(deltakerlisteId: UUID) = deltakerRepository.getForDeltakerliste(deltakerlisteId)
 
-    fun oppdaterDeltakere(oppdaterteDeltakere: List<Deltaker>) = deltakerRepository.updateBatch(oppdaterteDeltakere)
+    fun oppdaterDeltakere(oppdaterteDeltakere: List<Deltakeroppdatering>) = deltakerRepository.updateBatch(oppdaterteDeltakere)
 }
 
 fun Deltaker.oppdater(oppdatering: Deltakeroppdatering) = this.copy(
@@ -308,4 +308,18 @@ fun Deltaker.oppdater(oppdatering: Deltakeroppdatering) = this.copy(
     deltakelsesinnhold = oppdatering.deltakelsesinnhold,
     status = oppdatering.status,
     historikk = oppdatering.historikk,
+)
+
+fun Deltaker.toDeltakeroppdatering() = Deltakeroppdatering(
+    id = id,
+    startdato = startdato,
+    sluttdato = sluttdato,
+    dagerPerUke = dagerPerUke,
+    deltakelsesprosent = deltakelsesprosent,
+    bakgrunnsinformasjon = bakgrunnsinformasjon,
+    deltakelsesinnhold = deltakelsesinnhold,
+    status = status,
+    historikk = historikk,
+    erManueltDeltMedArrangor = erManueltDeltMedArrangor,
+    sistEndret = sistEndret,
 )

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/AmtDeltakerClient.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/AmtDeltakerClient.kt
@@ -48,12 +48,12 @@ class AmtDeltakerClient(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    suspend fun settPaaVenteliste(deltakerIder: List<UUID>, deltakerlisteId: UUID): List<Deltaker> {
+    suspend fun settPaaVenteliste(deltakerIder: List<UUID>, endretAv: String): List<Deltaker> {
         val token = azureAdTokenClient.getMachineToMachineToken(scope)
         val response = httpClient.post("$baseUrl/tiltakskoordinator/deltakere/sett-paa-venteliste") {
             header(HttpHeaders.Authorization, token)
             header(HttpHeaders.ContentType, ContentType.Application.Json)
-            setBody(DeltakereRequest(deltakerIder, deltakerlisteId))
+            setBody(DeltakereRequest(deltakerIder, endretAv))
         }
 
         if (!response.status.isSuccess()) {
@@ -357,7 +357,7 @@ class AmtDeltakerClient(
 
 data class DeltakereRequest(
     val deltakere: List<UUID>,
-    val deltakerlisteId: UUID,
+    val endretAv: String,
 )
 
 private fun Utkast.toRequest() = UtkastRequest(

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/AmtDeltakerClient.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/amtdeltaker/AmtDeltakerClient.kt
@@ -28,7 +28,6 @@ import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.request.StartdatoRequest
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.request.UtkastRequest
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.response.DeltakerMedStatusResponse
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.response.KladdResponse
-import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.Deltakeroppdatering
 import no.nav.amt.deltaker.bff.deltaker.model.Utkast
 import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
@@ -48,7 +47,7 @@ class AmtDeltakerClient(
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    suspend fun settPaaVenteliste(deltakerIder: List<UUID>, endretAv: String): List<Deltaker> {
+    suspend fun settPaaVenteliste(deltakerIder: List<UUID>, endretAv: String): List<Deltakeroppdatering> {
         val token = azureAdTokenClient.getMachineToMachineToken(scope)
         val response = httpClient.post("$baseUrl/tiltakskoordinator/deltakere/sett-paa-venteliste") {
             header(HttpHeaders.Authorization, token)

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -370,7 +370,7 @@ class DeltakerRepository {
         }
     }
 
-    fun updateBatch(deltakere: List<Deltaker>) = Database.query { session ->
+    fun updateBatch(deltakere: List<Deltakeroppdatering>) = Database.query { session ->
         val deltakerParams = deltakere.map { batchUpdateDeltakerParams(it) }
         val statusParams = deltakere.map { insertStatusParams(it.status, it.id) }
         val deaktiverTidligereStatuserParams = deltakere.map { deaktiverTidligereStatuserParams(it.status, it.id) }
@@ -605,7 +605,7 @@ class DeltakerRepository {
         return queryOf(sql, params)
     }
 
-    private fun batchUpdateDeltakerParams(deltaker: Deltaker) = mapOf(
+    private fun batchUpdateDeltakerParams(deltaker: Deltakeroppdatering) = mapOf(
         "id" to deltaker.id,
         "startdato" to deltaker.startdato,
         "sluttdato" to deltaker.sluttdato,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/kafka/DeltakerV2Dto.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/kafka/DeltakerV2Dto.kt
@@ -51,6 +51,7 @@ data class DeltakerV2Dto(
             ),
             historikk = historikk.orEmpty(),
             sistEndret = sistEndret ?: LocalDateTime.now(),
+            erManueltDeltMedArrangor = erManueltDeltMedArrangor,
             forcedUpdate = forcedUpdate,
         )
     }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltakeroppdatering.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/model/Deltakeroppdatering.kt
@@ -18,5 +18,6 @@ data class Deltakeroppdatering(
     val status: DeltakerStatus,
     val historikk: List<DeltakerHistorikk>,
     val sistEndret: LocalDateTime = LocalDateTime.now(),
+    val erManueltDeltMedArrangor: Boolean,
     val forcedUpdate: Boolean? = false,
 )

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorService.kt
@@ -4,6 +4,8 @@ import no.nav.amt.deltaker.bff.auth.TiltakskoordinatorTilgangRepository
 import no.nav.amt.deltaker.bff.deltaker.DeltakerService
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.AmtDeltakerClient
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
+import no.nav.amt.deltaker.bff.deltaker.model.Deltakeroppdatering
+import no.nav.amt.deltaker.bff.deltaker.toDeltakeroppdatering
 import no.nav.amt.deltaker.bff.deltaker.vurdering.VurderingService
 import no.nav.amt.deltaker.bff.navansatt.NavAnsatt
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
@@ -48,14 +50,14 @@ class TiltakskoordinatorService(
                     .delMedArrangor(deltakerIder, endretAv)
                 val deltakere = deltakerService.getMany(deltakerIder).associateBy { it.id }
                 res.mapNotNull { oppdatering ->
-                    deltakere[oppdatering.id]?.oppdater(oppdatering)
+                    deltakere[oppdatering.id]?.oppdater(oppdatering)?.toDeltakeroppdatering()
                 }
             }
         }
 
         deltakerService.oppdaterDeltakere(oppdaterteDeltakere)
 
-        return oppdaterteDeltakere.toTiltakskoordinatorsDeltaker()
+        return oppdaterteDeltakere.toTiltakskoordinatorsDeltakere()
     }
 
     fun hentKoordinatorer(deltakerlisteId: UUID) = tiltakskoordinatorTilgangRepository.hentKoordinatorer(deltakerlisteId)
@@ -90,6 +92,11 @@ class TiltakskoordinatorService(
                 navVeiledere[it.navBruker.navVeilederId],
             )
         }.filterNot { it.skalSkjules() }
+    }
+
+    private fun List<Deltakeroppdatering>.toTiltakskoordinatorsDeltakere(): List<TiltakskoordinatorsDeltaker> {
+        val deltakere = deltakerService.getMany(this.map { it.id })
+        return deltakere.toTiltakskoordinatorsDeltaker()
     }
 }
 

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorService.kt
@@ -34,6 +34,19 @@ class TiltakskoordinatorService(
         return deltaker.toTiltakskoordinatorsDeltaker(sisteVurdering, navEnhet, navVeileder)
     }
 
+    suspend fun settPaaVenteliste(deltakerIder: List<UUID>, deltakerlisteId: UUID): List<TiltakskoordinatorsDeltaker> {
+        return endreDeltakere {
+            amtDeltakerClient.settPaaVenteliste(deltakerIder, deltakerlisteId)
+        }
+    }
+
+    suspend fun endreDeltakere(postEndring: suspend () -> List<Deltaker>): List<TiltakskoordinatorsDeltaker> {
+        val oppdaterteDeltakere = postEndring()
+        deltakerService.oppdaterDeltakere(oppdaterteDeltakere)
+
+        return oppdaterteDeltakere.toTiltakskoordinatorsDeltaker()
+    }
+
     suspend fun endreDeltakere(
         deltakerIder: List<UUID>,
         endring: EndringFraTiltakskoordinator.Endring,

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/api/TiltakskoordinatorDeltakerlisteApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/api/TiltakskoordinatorDeltakerlisteApi.kt
@@ -61,6 +61,19 @@ fun Routing.registerTiltakskoordinatorDeltakerlisteApi(
             call.respond(deltakere)
         }
 
+        post("$apiPath/deltakere/sett-paa-venteliste") {
+            val deltakerRequest = call.receive<DeltakereRequest>()
+            val deltakerlisteId = getDeltakerlisteId()
+            val deltakerIder = deltakerRequest.deltakere
+
+            tilgangskontrollService.verifiserTiltakskoordinatorTilgang(call.getNavIdent(), deltakerlisteId)
+            deltakerlisteService.verifiserTilgjengeligDeltakerliste(deltakerlisteId)
+
+            tiltakskoordinatorService.settPaaVenteliste(deltakerIder, deltakerlisteId)
+
+            call.respond(HttpStatusCode.OK)
+        }
+
         post("$apiPath/deltakere/del-med-arrangor") {
             val deltakerlisteId = getDeltakerlisteId()
             val navIdent = call.getNavIdent()
@@ -116,6 +129,10 @@ fun TiltakskoordinatorsDeltaker.toDeltakerResponse(harTilgang: Boolean): Deltake
         erManueltDeltMedArrangor = erManueltDeltMedArrangor,
     )
 }
+
+data class DeltakereRequest(
+    val deltakere: List<UUID>,
+)
 
 fun RoutingContext.getDeltakerlisteId(): UUID {
     val id =

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/api/TiltakskoordinatorDeltakerlisteApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/api/TiltakskoordinatorDeltakerlisteApi.kt
@@ -59,9 +59,8 @@ fun Routing.registerTiltakskoordinatorDeltakerlisteApi(
         post("$apiPath/deltakere/sett-paa-venteliste") {
             val navAnsattAzureId = call.getNavAnsattAzureId()
             val navIdent = call.getNavIdent()
-            val deltakerRequest = call.receive<DeltakereRequest>()
+            val deltakerIder = call.receive<List<UUID>>()
             val deltakerlisteId = getDeltakerlisteId()
-            val deltakerIder = deltakerRequest.deltakere
 
             tilgangskontrollService.tilgangTilDeltakereGuard(deltakerIder, deltakerlisteId, navIdent)
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/application/plugins/AuthenticationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/application/plugins/AuthenticationTest.kt
@@ -18,7 +18,9 @@ import junit.framework.TestCase
 import no.nav.amt.deltaker.bff.Environment
 import no.nav.amt.deltaker.bff.auth.TilgangskontrollService
 import no.nav.amt.deltaker.bff.auth.TiltakskoordinatorTilgangRepository
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteService
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
+import no.nav.amt.deltaker.bff.tiltakskoordinator.TiltakskoordinatorService
 import no.nav.amt.deltaker.bff.utils.configureEnvForAuthentication
 import no.nav.amt.deltaker.bff.utils.generateJWT
 import no.nav.poao_tilgang.client.Decision
@@ -37,6 +39,8 @@ class AuthenticationTest {
         navAnsattService,
         tiltakskoordinatorTilgangRepository,
         mockk(relaxed = true),
+        mockk<TiltakskoordinatorService>(),
+        mockk<DeltakerlisteService>(),
     )
 
     @Before

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/auth/TilgangskontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/auth/TilgangskontrollServiceTest.kt
@@ -4,10 +4,12 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteService
 import no.nav.amt.deltaker.bff.kafka.utils.assertProduced
 import no.nav.amt.deltaker.bff.kafka.utils.assertProducedTombstone
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattRepository
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
+import no.nav.amt.deltaker.bff.tiltakskoordinator.TiltakskoordinatorService
 import no.nav.amt.lib.kafka.Producer
 import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.testing.SingletonKafkaProvider
@@ -37,6 +39,8 @@ class TilgangskontrollServiceTest {
         navAnsattService,
         tiltakskoordinatorTilgangRepository,
         tiltakskoordinatorsDeltakerlisteProducer,
+        mockk<TiltakskoordinatorService>(),
+        mockk<DeltakerlisteService>(),
     )
 
     init {

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerServiceTest.kt
@@ -157,6 +157,7 @@ class DeltakerServiceTest {
             bakgrunnsinformasjon = "Tekst",
             deltakelsesinnhold = null,
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.UTKAST_TIL_PAMELDING),
+            erManueltDeltMedArrangor = false,
             historikk = emptyList(),
         )
 
@@ -185,6 +186,7 @@ class DeltakerServiceTest {
                 aarsak = DeltakerStatus.Aarsak.Type.ANNET,
                 beskrivelse = "Oppdatert",
             ),
+            erManueltDeltMedArrangor = false,
             historikk = emptyList(),
         )
 
@@ -219,6 +221,7 @@ class DeltakerServiceTest {
             bakgrunnsinformasjon = "Tekst",
             deltakelsesinnhold = Deltakelsesinnhold("ny ledetekst", listOf(Innhold("", "", true, ""))),
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.UTKAST_TIL_PAMELDING),
+            erManueltDeltMedArrangor = false,
             historikk = emptyList(),
         )
 
@@ -255,6 +258,7 @@ class DeltakerServiceTest {
             bakgrunnsinformasjon = "Tekst",
             deltakelsesinnhold = null,
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+            erManueltDeltMedArrangor = false,
             historikk = emptyList(),
         )
 
@@ -280,6 +284,7 @@ class DeltakerServiceTest {
             bakgrunnsinformasjon = null,
             deltakelsesinnhold = null,
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.FEILREGISTRERT),
+            erManueltDeltMedArrangor = false,
             historikk = emptyList(),
         )
 
@@ -311,6 +316,7 @@ class DeltakerServiceTest {
                 type = DeltakerStatus.Type.IKKE_AKTUELL,
                 aarsak = DeltakerStatus.Aarsak.Type.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT,
             ),
+            erManueltDeltMedArrangor = false,
             historikk = emptyList(),
         )
 
@@ -323,7 +329,7 @@ class DeltakerServiceTest {
     }
 }
 
-fun DeltakerEndring.Aarsak.toDeltakerStatusAarsak() = no.nav.amt.lib.models.deltaker.DeltakerStatus.Aarsak(
+fun DeltakerEndring.Aarsak.toDeltakerStatusAarsak() = DeltakerStatus.Aarsak(
     no.nav.amt.lib.models.deltaker.DeltakerStatus.Aarsak.Type
         .valueOf(type.name),
     beskrivelse,

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApiTest.kt
@@ -38,6 +38,7 @@ import no.nav.amt.deltaker.bff.navansatt.NavAnsatt
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhet
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
+import no.nav.amt.deltaker.bff.tiltakskoordinator.TiltakskoordinatorService
 import no.nav.amt.deltaker.bff.utils.configureEnvForAuthentication
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
@@ -64,6 +65,8 @@ class PameldingApiTest {
         navAnsattService,
         tiltakskoordinatorTilgangRepository,
         tiltakskoordinatorsDeltakerlisteProducer,
+        mockk<TiltakskoordinatorService>(),
+        mockk<DeltakerlisteService>(),
     )
     private val deltakerlisteService = mockk<DeltakerlisteService>()
 

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/TiltakskoordinatorDeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/TiltakskoordinatorDeltakerApiTest.kt
@@ -52,11 +52,13 @@ import no.nav.amt.deltaker.bff.deltaker.api.utils.postRequest
 import no.nav.amt.deltaker.bff.deltaker.forslag.ForslagService
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.toDeltakerStatusAarsak
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteService
 import no.nav.amt.deltaker.bff.navansatt.NavAnsatt
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhet
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import no.nav.amt.deltaker.bff.sporbarhet.SporbarhetsloggService
+import no.nav.amt.deltaker.bff.tiltakskoordinator.TiltakskoordinatorService
 import no.nav.amt.deltaker.bff.unleash.UnleashToggle
 import no.nav.amt.deltaker.bff.utils.configureEnvForAuthentication
 import no.nav.amt.deltaker.bff.utils.data.TestData
@@ -87,11 +89,15 @@ class TiltakskoordinatorDeltakerApiTest {
     private val unleashToggle = mockk<UnleashToggle>()
     private val tiltakskoordinatorTilgangRepository = mockk<TiltakskoordinatorTilgangRepository>()
     private val tiltakskoordinatorsDeltakerlisteProducer = mockk<TiltakskoordinatorsDeltakerlisteProducer>()
+    private val deltakerlisteService = mockk<DeltakerlisteService>()
+    private val tiltakskoordinatorService = mockk<TiltakskoordinatorService>()
     private val tilgangskontrollService = TilgangskontrollService(
         poaoTilgangCachedClient,
         navAnsattService,
         tiltakskoordinatorTilgangRepository,
         tiltakskoordinatorsDeltakerlisteProducer,
+        tiltakskoordinatorService,
+        deltakerlisteService,
     )
 
     @Before

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/utils/Requests.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/utils/Requests.kt
@@ -40,6 +40,23 @@ internal fun HttpRequestBuilder.noBodyRequest() {
     header("aktiv-enhet", "0101")
 }
 
+internal fun HttpRequestBuilder.postTiltakskoordinatorRequest(body: Any) {
+    header(
+        HttpHeaders.Authorization,
+        "Bearer ${
+            generateJWT(
+                consumerClientId = "frontend-clientid",
+                navAnsattAzureId = UUID.randomUUID().toString(),
+                audience = "deltaker-bff",
+                groups = listOf(UUID(0L, 0L).toString()),
+            )
+        }",
+    )
+    header("aktiv-enhet", "0101")
+    contentType(ContentType.Application.Json)
+    setBody(objectMapper.writeValueAsString(body))
+}
+
 internal fun HttpRequestBuilder.noBodyTiltakskoordinatorRequest() {
     header(
         HttpHeaders.Authorization,

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -1,11 +1,8 @@
 package no.nav.amt.deltaker.bff.deltaker.db
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import no.nav.amt.deltaker.bff.application.plugins.objectMapper
-import no.nav.amt.deltaker.bff.application.plugins.writePolymorphicListAsString
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.response.KladdResponse
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
 import no.nav.amt.deltaker.bff.deltaker.model.Deltakeroppdatering
@@ -109,9 +106,6 @@ class DeltakerRepositoryTest {
         val deltaker = TestData.leggTilHistorikk(baseDeltaker, 2)
 
         TestRepository.insert(deltaker)
-
-        val json = objectMapper.writePolymorphicListAsString(deltaker.historikk)
-        val historikk = objectMapper.readValue<List<DeltakerHistorikk>>(json)
 
         val vedtak = repository.get(baseDeltaker.id).getOrThrow().fattetVedtak!!
         vedtak.fattet shouldNotBe null
@@ -402,7 +396,7 @@ class DeltakerRepositoryTest {
             erManueltDeltMedArrangor = true,
         )
 
-        repository.updateBatch(listOf(oppdatertDeltaker1, oppdatertDeltaker2))
+        repository.updateBatch(listOf(oppdatertDeltaker1.toDeltakeroppdatering(), oppdatertDeltaker2.toDeltakeroppdatering()))
 
         val deltaker1FraDB = repository.get(deltaker1.id).getOrThrow()
         sammenlignDeltakere(deltaker1FraDB, oppdatertDeltaker1)
@@ -436,6 +430,7 @@ private fun Deltaker.toDeltakeroppdatering() = Deltakeroppdatering(
     status,
     historikk,
     sistEndret,
+    erManueltDeltMedArrangor,
 )
 
 fun sammenlignDeltakere(a: Deltaker, b: Deltaker) {

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerApiTest.kt
@@ -29,11 +29,13 @@ import no.nav.amt.deltaker.bff.deltaker.api.model.getArrangorNavn
 import no.nav.amt.deltaker.bff.deltaker.api.model.toResponse
 import no.nav.amt.deltaker.bff.deltaker.forslag.ForslagService
 import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteService
 import no.nav.amt.deltaker.bff.innbygger.model.toInnbyggerDeltakerResponse
 import no.nav.amt.deltaker.bff.navansatt.NavAnsatt
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhet
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
+import no.nav.amt.deltaker.bff.tiltakskoordinator.TiltakskoordinatorService
 import no.nav.amt.deltaker.bff.utils.configureEnvForAuthentication
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.tokenXToken
@@ -59,11 +61,15 @@ class InnbyggerApiTest {
     private val amtDistribusjonClient = mockk<AmtDistribusjonClient>()
     private val tiltakskoordinatorTilgangRepository = mockk<TiltakskoordinatorTilgangRepository>()
     private val tiltakskoordinatorsDeltakerlisteProducer = mockk<TiltakskoordinatorsDeltakerlisteProducer>()
+    private val tiltakskoordinatorService = mockk<TiltakskoordinatorService>()
+    private val deltakerlisteService = mockk<DeltakerlisteService>()
     private val tilgangskontrollService = TilgangskontrollService(
         poaoTilgangCachedClient,
         navAnsattService,
         tiltakskoordinatorTilgangRepository,
         tiltakskoordinatorsDeltakerlisteProducer,
+        tiltakskoordinatorService,
+        deltakerlisteService,
     )
 
     @Before

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
@@ -1,6 +1,7 @@
 package no.nav.amt.deltaker.bff.tiltakskoordinator
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -68,7 +69,8 @@ class TiltakskoordinatorServiceIntegrationTest {
         )
         val resultDeltaker = resultatFraAmtDeltaker.first()
         resultatFraAmtDeltaker.size shouldBe 1
-        resultDeltaker.status shouldBe nyStatus
+        resultDeltaker.status.id shouldNotBe deltaker.status.id
+        resultDeltaker.status.trimMss().copy(id = nyStatus.id) shouldBe nyStatus.trimMss()
 
         coEvery { navAnsattService.hentEllerOpprettNavAnsatt(navAnsatt.id) } returns navAnsatt
         coEvery { navEnhetService.hentEnhet(navEnhet.id) } returns navEnhet
@@ -80,20 +82,21 @@ class TiltakskoordinatorServiceIntegrationTest {
     }
 }
 
-infix fun TiltakskoordinatorsDeltaker.shouldBeCloseTo(expected: TiltakskoordinatorsDeltaker?) {
-    fun LocalDateTime.atStartOfDay() = this.toLocalDate().atStartOfDay()
+fun LocalDateTime.atStartOfDay(): LocalDateTime = this.toLocalDate().atStartOfDay()
 
+fun DeltakerStatus.trimMss() = this.copy(
+    opprettet = this.opprettet.atStartOfDay(),
+    gyldigFra = this.gyldigFra.atStartOfDay(),
+)
+
+infix fun TiltakskoordinatorsDeltaker.shouldBeCloseTo(expected: TiltakskoordinatorsDeltaker?) {
     this.copy(
-        status = status.copy(
+        status = status.trimMss().copy(
             id = expected!!.status.id,
-            opprettet = this.status.opprettet.atStartOfDay(),
-            gyldigFra = this.status.gyldigFra.atStartOfDay(),
         ),
     ) shouldBe expected.copy(
-        status = expected.status.copy(
+        status = expected.status.trimMss().copy(
             id = expected.status.id,
-            opprettet = expected.status.opprettet.atStartOfDay(),
-            gyldigFra = expected.status.gyldigFra.atStartOfDay(),
         ),
     )
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
@@ -81,16 +81,13 @@ class TiltakskoordinatorServiceIntegrationTest {
 }
 
 infix fun TiltakskoordinatorsDeltaker.shouldBeCloseTo(expected: TiltakskoordinatorsDeltaker?) {
-    val statusOpprettetDay = this.status.opprettet.toLocalDate().atStartOfDay()
-    val gyldigFra = this.status.gyldigFra.toLocalDate().atStartOfDay()
-
     fun LocalDateTime.atStartOfDay() = this.toLocalDate().atStartOfDay()
 
     this.copy(
         status = status.copy(
             id = expected!!.status.id,
-            opprettet = statusOpprettetDay,
-            gyldigFra = gyldigFra,
+            opprettet = this.status.opprettet.atStartOfDay(),
+            gyldigFra = this.status.gyldigFra.atStartOfDay(),
         ),
     ) shouldBe expected.copy(
         status = expected.status.copy(

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
@@ -1,0 +1,74 @@
+package no.nav.amt.deltaker.bff.tiltakskoordinator
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.amt.deltaker.bff.auth.TiltakskoordinatorTilgangRepository
+import no.nav.amt.deltaker.bff.deltaker.DeltakerService
+import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.AmtDeltakerClient
+import no.nav.amt.deltaker.bff.deltaker.db.DeltakerRepository
+import no.nav.amt.deltaker.bff.deltaker.forslag.ForslagService
+import no.nav.amt.deltaker.bff.deltaker.vurdering.VurderingService
+import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
+import no.nav.amt.deltaker.bff.utils.data.TestData
+import no.nav.amt.deltaker.bff.utils.data.TestRepository
+import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.testing.SingletonPostgres16Container
+import org.junit.Test
+import java.time.LocalDateTime
+import java.util.UUID
+
+class TiltakskoordinatorServiceIntegrationTest {
+    init {
+        SingletonPostgres16Container
+    }
+
+    private val amtDeltakerClient = mockk<AmtDeltakerClient>()
+    private val navEnhetService = mockk<NavEnhetService>()
+    private val navAnsattService = mockk<NavAnsattService>()
+    private val vurderingService = mockk<VurderingService>()
+    private val deltakerService = DeltakerService(DeltakerRepository(), amtDeltakerClient, navEnhetService, mockk<ForslagService>())
+    private val tiltakskoordinatorService = TiltakskoordinatorService(
+        amtDeltakerClient,
+        deltakerService,
+        mockk<TiltakskoordinatorTilgangRepository>(),
+        vurderingService,
+        navEnhetService,
+        navAnsattService,
+    )
+
+    @Test
+    fun `settPaaVenteliste - returnerer og lagrer deltaker med ny status`(): Unit = runBlocking {
+        val deltaker = TestData.lagDeltaker()
+        val navEnhet = TestData.lagNavEnhet(id = deltaker.navBruker.navEnhetId!!)
+        val navAnsatt = TestData.lagNavAnsatt(id = deltaker.navBruker.navVeilederId!!)
+
+        TestRepository.insert(deltaker)
+        every { vurderingService.getSisteVurderingForDeltaker(deltaker.id) } returns null
+        every { navEnhetService.hentEnheter(listOf(navEnhet.id)) } returns mapOf(navEnhet.id to navEnhet)
+        every { navAnsattService.hentAnsatte(listOf(navAnsatt.id)) } returns mapOf(navAnsatt.id to navAnsatt)
+
+        val nyStatus =
+            DeltakerStatus(UUID.randomUUID(), DeltakerStatus.Type.VENTELISTE, null, LocalDateTime.now(), null, LocalDateTime.now())
+
+        coEvery {
+            amtDeltakerClient.settPaaVenteliste(listOf(deltaker.id), deltaker.deltakerliste.id)
+        } returns listOf(deltaker.copy(status = nyStatus))
+
+        val resultatFraAmtDeltaker = tiltakskoordinatorService.settPaaVenteliste(listOf(deltaker.id), deltaker.deltakerliste.id)
+        val resultDeltaker = resultatFraAmtDeltaker.first()
+        resultatFraAmtDeltaker.size shouldBe 1
+        resultDeltaker.status shouldBe nyStatus
+
+        coEvery { navAnsattService.hentEllerOpprettNavAnsatt(navAnsatt.id) } returns navAnsatt
+        coEvery { navEnhetService.hentEnhet(navEnhet.id) } returns navEnhet
+
+        val deltakerFraDb = tiltakskoordinatorService.get(deltaker.id)
+        deltakerFraDb shouldBe deltaker
+            .copy(status = nyStatus)
+            .toTiltakskoordinatorsDeltaker(null, navEnhet, navAnsatt)
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
@@ -10,6 +10,7 @@ import no.nav.amt.deltaker.bff.deltaker.DeltakerService
 import no.nav.amt.deltaker.bff.deltaker.amtdeltaker.AmtDeltakerClient
 import no.nav.amt.deltaker.bff.deltaker.db.DeltakerRepository
 import no.nav.amt.deltaker.bff.deltaker.forslag.ForslagService
+import no.nav.amt.deltaker.bff.deltaker.toDeltakeroppdatering
 import no.nav.amt.deltaker.bff.deltaker.vurdering.VurderingService
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
@@ -58,7 +59,7 @@ class TiltakskoordinatorServiceIntegrationTest {
 
         coEvery {
             amtDeltakerClient.settPaaVenteliste(listOf(deltaker.id), navAnsatt.navIdent)
-        } returns listOf(deltaker.copy(status = nyStatus))
+        } returns listOf(deltaker.copy(status = nyStatus).toDeltakeroppdatering())
 
         val resultatFraAmtDeltaker = tiltakskoordinatorService.endreDeltakere(
             listOf(deltaker.id),

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
@@ -13,6 +13,7 @@ import no.nav.amt.deltaker.bff.deltaker.forslag.ForslagService
 import no.nav.amt.deltaker.bff.deltaker.vurdering.VurderingService
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
+import no.nav.amt.deltaker.bff.tiltakskoordinator.model.TiltakskoordinatorsDeltaker
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
@@ -72,8 +73,29 @@ class TiltakskoordinatorServiceIntegrationTest {
         coEvery { navEnhetService.hentEnhet(navEnhet.id) } returns navEnhet
 
         val deltakerFraDb = tiltakskoordinatorService.get(deltaker.id)
-        deltakerFraDb shouldBe deltaker
+        deltakerFraDb shouldBeCloseTo deltaker
             .copy(status = nyStatus)
             .toTiltakskoordinatorsDeltaker(null, navEnhet, navAnsatt)
     }
+}
+
+infix fun TiltakskoordinatorsDeltaker.shouldBeCloseTo(expected: TiltakskoordinatorsDeltaker?) {
+    val statusOpprettetDay = this.status.opprettet.toLocalDate().atStartOfDay()
+    val gyldigFra = this.status.gyldigFra.toLocalDate().atStartOfDay()
+
+    fun LocalDateTime.atStartOfDay() = this.toLocalDate().atStartOfDay()
+
+    this.copy(
+        status = status.copy(
+            id = expected!!.status.id,
+            opprettet = statusOpprettetDay,
+            gyldigFra = gyldigFra,
+        ),
+    ) shouldBe expected.copy(
+        status = expected.status.copy(
+            id = expected.status.id,
+            opprettet = expected.status.opprettet.atStartOfDay(),
+            gyldigFra = expected.status.gyldigFra.atStartOfDay(),
+        ),
+    )
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorServiceIntegrationTest.kt
@@ -16,6 +16,7 @@ import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import no.nav.amt.deltaker.bff.utils.data.TestData
 import no.nav.amt.deltaker.bff.utils.data.TestRepository
 import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.tiltakskoordinator.EndringFraTiltakskoordinator
 import no.nav.amt.lib.testing.SingletonPostgres16Container
 import org.junit.Test
 import java.time.LocalDateTime
@@ -55,10 +56,14 @@ class TiltakskoordinatorServiceIntegrationTest {
             DeltakerStatus(UUID.randomUUID(), DeltakerStatus.Type.VENTELISTE, null, LocalDateTime.now(), null, LocalDateTime.now())
 
         coEvery {
-            amtDeltakerClient.settPaaVenteliste(listOf(deltaker.id), deltaker.deltakerliste.id)
+            amtDeltakerClient.settPaaVenteliste(listOf(deltaker.id), navAnsatt.navIdent)
         } returns listOf(deltaker.copy(status = nyStatus))
 
-        val resultatFraAmtDeltaker = tiltakskoordinatorService.settPaaVenteliste(listOf(deltaker.id), deltaker.deltakerliste.id)
+        val resultatFraAmtDeltaker = tiltakskoordinatorService.endreDeltakere(
+            listOf(deltaker.id),
+            EndringFraTiltakskoordinator.SettPaaVenteliste,
+            navAnsatt.navIdent,
+        )
         val resultDeltaker = resultatFraAmtDeltaker.first()
         resultatFraAmtDeltaker.size shouldBe 1
         resultDeltaker.status shouldBe nyStatus

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/MockHttpClient.kt
@@ -222,4 +222,5 @@ fun Deltaker.toDeltakeroppdatering() = Deltakeroppdatering(
     deltakelsesinnhold,
     status,
     historikk,
+    erManueltDeltMedArrangor = erManueltDeltMedArrangor,
 )


### PR DESCRIPTION
* Implementerer funksjonalitet for å sette på venteliste
* Splitter ut tilgangskontroll i egen guard som kan brukes på tvers (her burde vi kanskje flyttet exception kasting til controlleren og returnere Result objekt men det krever mer omskriving av tilgangskontroll kode som er gjenbrukt nå)

Mangler noe feilhåndtering, som kommer etterpå(hva skjer hvis oppdatering på 1 av 5 deltakere feiler?)

https://trello.com/c/UtFz5diC/2224-tiltakskoordinator-kan-sette-p%C3%A5-venteliste