### PR TITLE
alltid lagre feilregistrert status

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -510,6 +510,10 @@ class DeltakerRepository {
       """
 
     private fun skalOppdateres(eksisterendeDeltaker: Deltaker?, oppdatering: Deltakeroppdatering): Boolean {
+        if (oppdatering.status.type == DeltakerStatus.Type.FEILREGISTRERT) {
+            return true
+        }
+
         if (eksisterendeDeltaker == null) {
             log.info("Deltakeren finnes ikke fra før, oppdaterer ${oppdatering.id}")
             return true


### PR DESCRIPTION
https://trello.com/c/gVrpjQno/2320-feilregistrering-av-deltakere-setter-ikke-statuser-riktig

Retter feil som gjør at vi ikke lagrer oppdateringen når vi feilregistrerer deltakere som fører til at de i realiteten ikke blir feilregistrert og dataene blir liggende igjen