### PR TITLE
Retter feil som gjør at vi ikke får inn siste data på importerte deltakere som ikke har endret størrelse i historikk

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -524,11 +524,6 @@ class DeltakerRepository {
             return true
         }
 
-        if (eksisterendeDeltaker.status.type == DeltakerStatus.Type.FEILREGISTRERT) {
-            log.info("Har mottatt oppdatering på feilregistrert deltaker, ignorerer, ${oppdatering.id}")
-            return false
-        }
-
         val erUtkast = oppdatering.status.type == DeltakerStatus.Type.UTKAST_TIL_PAMELDING &&
             eksisterendeDeltaker.status.type == DeltakerStatus.Type.UTKAST_TIL_PAMELDING
 
@@ -537,7 +532,7 @@ class DeltakerRepository {
 
         val kanOppdateres = eksisterendeDeltaker.kanEndres &&
             (
-                oppdatering.historikk.size > eksisterendeDeltaker.historikk.size ||
+                oppdatering.historikk.size >= eksisterendeDeltaker.historikk.size ||
                     oppdateringHarNyereStatus ||
                     erUtkast
             )

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -154,17 +154,6 @@ class DeltakerRepositoryTest {
     }
 
     @Test
-    fun `update - deltaker endringshistorikk mangler - oppdaterer ikke`() {
-        val deltaker = TestData.lagDeltaker()
-        TestRepository.insert(deltaker)
-        val oppdatertDeltaker = deltaker.copy(bakgrunnsinformasjon = "Endringshistorikk mangler")
-
-        repository.update(oppdatertDeltaker.toDeltakeroppdatering())
-
-        sammenlignDeltakere(repository.get(deltaker.id).getOrThrow(), deltaker)
-    }
-
-    @Test
     fun `update - deltaker endringshistorikk mangler men er utkast - oppdaterer`() {
         val deltaker = TestData.lagDeltaker(
             status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.UTKAST_TIL_PAMELDING),


### PR DESCRIPTION

Jeg tror hele denne sjekken på historikk bør fjernes men tør ikke fjerne den nå siden vi nettopp har lansert