### PR TITLE
Lager spesialtilfelle som skal tillate at man er 19 år når man melder på

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/DeltakerlisteService.kt
@@ -49,8 +49,15 @@ class DeltakerlisteService(
         }
 
         val fodselsar = amtPersonServiceClient.hentNavBrukerFodselsar(personident)
+        val dagensDato = LocalDate.now()
 
-        if (deltakerliste.startDato.year - fodselsar < GRUPPE_FAG_OG_YRKE_OG_AMO_ALDERSGRENSE) {
+        if (deltakerliste.startDato.isBefore(dagensDato)) {
+            // For kurstiltak med løpende oppstart så kan oppstartsdatoen på kurset være i fortiden når man melder på
+            // og da må personen ha fylt 19 år på tidspunktet som man melder på
+            if (dagensDato.year - fodselsar < GRUPPE_FAG_OG_YRKE_OG_AMO_ALDERSGRENSE) {
+                throw DeltakerForUngException("Deltaker er for ung for å delta på ${deltakerliste.tiltak.tiltakskode}")
+            }
+        } else if (deltakerliste.startDato.year - fodselsar < GRUPPE_FAG_OG_YRKE_OG_AMO_ALDERSGRENSE) {
             throw DeltakerForUngException("Deltaker er for ung for å delta på ${deltakerliste.tiltak.tiltakskode}")
         }
     }


### PR DESCRIPTION
 for å støtte tilfeller som oppstår når det er løpende oppstart og startdato har passert og personen fyller 19 inneværende år

https://trello.com/c/6WrqQPJv/2331-kurstiltak-med-l%C3%B8pende-oppstart-s%C3%A5-kan-man-ikke-melde-p%C3%A5-brukere-som-fyller-19-samme-%C3%A5r-og-kursets-oppstartsdato-er-i-fortiden