### PR TITLE
Endrer slik at bff leser endringer også på låste deltakere.

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -527,15 +527,12 @@ class DeltakerRepository {
         val erUtkast = oppdatering.status.type == DeltakerStatus.Type.UTKAST_TIL_PAMELDING &&
             eksisterendeDeltaker.status.type == DeltakerStatus.Type.UTKAST_TIL_PAMELDING
 
-        val oppdateringHarNyereStatus = oppdatering.status.opprettet.truncatedTo(ChronoUnit.MILLIS) >
+        val oppdateringHarNyereStatus = oppdatering.status.opprettet.truncatedTo(ChronoUnit.MILLIS) >=
             eksisterendeDeltaker.status.opprettet.truncatedTo(ChronoUnit.MILLIS)
 
-        val kanOppdateres = eksisterendeDeltaker.kanEndres &&
-            (
-                oppdatering.historikk.size >= eksisterendeDeltaker.historikk.size ||
-                    oppdateringHarNyereStatus ||
-                    erUtkast
-            )
+        val kanOppdateres = oppdatering.historikk.size >= eksisterendeDeltaker.historikk.size ||
+            oppdateringHarNyereStatus ||
+            erUtkast
 
         if (!kanOppdateres) {
             log.info(

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepository.kt
@@ -436,7 +436,7 @@ class DeltakerRepository {
         val params = mapOf("deltakerliste_id" to deltakerlisteId)
         session.run(
             queryOf(
-                getDeltakerSql("where dl.id = :deltakerliste_id and ds.gyldig_til is null"),
+                getDeltakerSql("where dl.id = :deltakerliste_id and ds.gyldig_til is null and d.kan_endres = true"),
                 params,
             ).map(::rowMapper).asList,
         )

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -175,6 +175,7 @@ class DeltakerRepositoryTest {
         repository.update(oppdatertDeltaker.toDeltakeroppdatering())
         sammenlignDeltakere(repository.get(deltaker.id).getOrThrow(), oppdatertDeltaker)
     }
+
     @Test
     fun `update - deltaker kan ikke endres - oppdaterer deltaker men beholder låsing`() {
         val sistEndret = LocalDateTime.now().minusDays(3)
@@ -188,6 +189,7 @@ class DeltakerRepositoryTest {
         sammenlignDeltakere(deltakerResultat, oppdatertDeltaker)
         deltakerResultat.kanEndres shouldBe false
     }
+
     @Test
     fun `update - deltaker kan ikke endres, kun oppdatert historikk - oppdaterer historikk`() {
         val sistEndret = LocalDateTime.now().minusDays(3)

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/db/DeltakerRepositoryTest.kt
@@ -175,9 +175,8 @@ class DeltakerRepositoryTest {
         repository.update(oppdatertDeltaker.toDeltakeroppdatering())
         sammenlignDeltakere(repository.get(deltaker.id).getOrThrow(), oppdatertDeltaker)
     }
-
     @Test
-    fun `update - deltaker kan ikke endres - oppdaterer ikke`() {
+    fun `update - deltaker kan ikke endres - oppdaterer deltaker men beholder låsing`() {
         val sistEndret = LocalDateTime.now().minusDays(3)
         val deltaker = TestData.lagDeltaker(sistEndret = sistEndret, kanEndres = false)
         TestRepository.insert(deltaker)
@@ -185,9 +184,10 @@ class DeltakerRepositoryTest {
         val oppdatertDeltaker = deltaker.endre(TestData.lagDeltakerEndring(endring = endring))
 
         repository.update(oppdatertDeltaker.toDeltakeroppdatering())
-        sammenlignDeltakere(repository.get(deltaker.id).getOrThrow(), deltaker)
+        val deltakerResultat = repository.get(deltaker.id).getOrThrow()
+        sammenlignDeltakere(deltakerResultat, oppdatertDeltaker)
+        deltakerResultat.kanEndres shouldBe false
     }
-
     @Test
     fun `update - deltaker kan ikke endres, kun oppdatert historikk - oppdaterer historikk`() {
         val sistEndret = LocalDateTime.now().minusDays(3)
@@ -440,6 +440,7 @@ fun sammenlignDeltakere(a: Deltaker, b: Deltaker) {
     a.status.gyldigTil shouldBeCloseTo b.status.gyldigTil
     a.status.opprettet shouldBeCloseTo b.status.opprettet
     a.erManueltDeltMedArrangor shouldBe b.erManueltDeltMedArrangor
+    a.kanEndres shouldBe b.kanEndres
 }
 
 private fun Deltaker.toKladdResponse() = KladdResponse(


### PR DESCRIPTION
* Dette pga problemer med at bff ikke inneholder siste data når det har oppstått situasjoner som gjør at amt-deltaker har oppdatert deltakeren uten bffens kjennskap(feks via koordinators flate)

Ønsker å ta bort de andre sjekkene i "kanEndres" også men tar litt av gangen nå fordi jeg er ikke sikekr på hvorfor det er innført så mange sjekker

https://trello.com/c/DFY0YWWU/2336-man-kan-tildele-plass-til-l%C3%A5ste-deltakelser-og-oppdateringer-som-f%C3%B8lge-av-tildelingen-vises-ikke-for-nav