### PR TITLE
Lagrer alle data som kommer på deltaker-v2 topic fordi vi i flere forskjellige tilfeller avviser data som burde vært lagret

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/DeltakerService.kt
@@ -264,7 +264,7 @@ class DeltakerService(
         }
     }
 
-    fun oppdaterDeltaker(deltakeroppdatering: Deltakeroppdatering) {
+    fun laasTidligereDeltakelser(deltakeroppdatering: Deltakeroppdatering) {
         if (deltakeroppdatering.status.type in AKTIVE_STATUSER && harEndretStatus(deltakeroppdatering)) {
             val tidligereDeltakelser = deltakerRepository.getTidligereAvsluttedeDeltakelser(deltakeroppdatering.id)
             deltakerRepository.settKanIkkeEndres(tidligereDeltakelser)
@@ -272,7 +272,12 @@ class DeltakerService(
                 "Har låst ${tidligereDeltakelser.size} deltakere for endringer pga nyere aktiv deltaker med id ${deltakeroppdatering.id}",
             )
         }
+    }
+
+    fun oppdaterDeltaker(deltakeroppdatering: Deltakeroppdatering) {
+        laasTidligereDeltakelser(deltakeroppdatering)
         deltakerRepository.update(deltakeroppdatering)
+
         if (deltakeroppdatering.status.type == DeltakerStatus.Type.FEILREGISTRERT ||
             deltakeroppdatering.status.aarsak?.type == DeltakerStatus.Aarsak.Type.SAMARBEIDET_MED_ARRANGOREN_ER_AVBRUTT
         ) {


### PR DESCRIPTION

* Ved synkrone kall fra fronend så ble amt-deltaker kalt og deretter kunne endringen bli avvist i bffen selv om deltakeren da allerede var lagret og lagt på kafka
* Flytter til guard som sørger for at oppdateringer som kommer fra frontend ikke blir lagret hvis deltakeren er låst
https://trello.com/c/W2imt04X/2322-h%C3%A5ndtering-av-oppdateringer-i-bffer-kan-f%C3%B8re-til-problemer-med-inkonsistende-data-mellom-bff-og-amt-deltaker