### PR TITLE
api for å opprette testdeltakelser

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -61,6 +61,8 @@ spec:
           namespace: team-mulighetsrommet
         - application: veilarbpersonflate
           namespace: poao
+        - application: tiltakspenger-tiltak
+          namespace: tpts
     outbound:
       rules:
         - application: amt-arrangor

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Application.kt
@@ -57,6 +57,7 @@ import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetRepository
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import no.nav.amt.deltaker.bff.sporbarhet.SporbarhetsloggService
+import no.nav.amt.deltaker.bff.testdata.TestdataService
 import no.nav.amt.deltaker.bff.tiltakskoordinator.TiltakskoordinatorService
 import no.nav.amt.deltaker.bff.unleash.UnleashToggle
 import no.nav.amt.lib.kafka.Producer
@@ -194,7 +195,8 @@ fun Application.module(): suspend () -> Unit {
     val deltakerRepository = DeltakerRepository()
 
     val forslagRepository = ForslagRepository()
-    val forslagService = ForslagService(forslagRepository, navAnsattService, navEnhetService, ArrangorMeldingProducer(kafkaProducer))
+    val arrangorMeldingProducer = ArrangorMeldingProducer(kafkaProducer)
+    val forslagService = ForslagService(forslagRepository, navAnsattService, navEnhetService, arrangorMeldingProducer)
 
     val vurderingRepository = VurderingRepository()
     val vurderingService = VurderingService(vurderingRepository)
@@ -230,6 +232,13 @@ fun Application.module(): suspend () -> Unit {
 
     val tiltakstypeRepository = TiltakstypeRepository()
 
+    val testdataService = TestdataService(
+        pameldingService = pameldingService,
+        deltakerlisteService = deltakerlisteService,
+        arrangorMeldingProducer = arrangorMeldingProducer,
+        deltakerService = deltakerService,
+    )
+
     val unleashToggle = UnleashToggle(unleash)
     val consumers = listOf(
         ArrangorConsumer(arrangorRepository),
@@ -258,6 +267,7 @@ fun Application.module(): suspend () -> Unit {
         deltakerlisteService,
         unleash,
         tiltakskoordinatorService,
+        testdataService,
     )
     configureMonitoring()
 

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/Environment.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/Environment.kt
@@ -1,5 +1,8 @@
 package no.nav.amt.deltaker.bff
 
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.auth.PreAuthorizedApp
 import no.nav.amt.lib.utils.database.DatabaseConfig
 import no.nav.amt.lib.utils.getEnvVar
 
@@ -28,6 +31,12 @@ data class Environment(
     val unleashUrl: String = getEnvVar(UNLEASH_SERVER_API_URL),
     val unleashApiToken: String = getEnvVar(UNLEASH_SERVER_API_TOKEN),
     val appName: String = "amt-deltaker-bff",
+    val preAuthorizedApp: List<PreAuthorizedApp> = getEnvVar(
+        AZURE_APP_PRE_AUTHORIZED_APPS,
+        objectMapper.writeValueAsString(
+            emptyList<PreAuthorizedApp>(),
+        ),
+    ).let { objectMapper.readValue(it) },
 ) {
     companion object {
         const val KAFKA_CONSUMER_GROUP_ID = "amt-deltaker-bff-consumer"
@@ -59,6 +68,7 @@ data class Environment(
         const val AZURE_APP_CLIENT_ID_KEY = "AZURE_APP_CLIENT_ID"
         const val AZURE_OPENID_CONFIG_JWKS_URI_KEY = "AZURE_OPENID_CONFIG_JWKS_URI"
         const val AZURE_OPENID_CONFIG_ISSUER_KEY = "AZURE_OPENID_CONFIG_ISSUER"
+        const val AZURE_APP_PRE_AUTHORIZED_APPS = "AZURE_APP_PRE_AUTHORIZED_APPS"
 
         const val AD_ROLLE_TILTAKSKOORDINATOR = "AD_ROLLE_TILTAKSKOORDINATOR"
 

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/application/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/application/plugins/Routing.kt
@@ -12,6 +12,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
+import no.nav.amt.deltaker.bff.Environment
 import no.nav.amt.deltaker.bff.application.registerHealthApi
 import no.nav.amt.deltaker.bff.auth.AuthenticationException
 import no.nav.amt.deltaker.bff.auth.AuthorizationException
@@ -33,6 +34,8 @@ import no.nav.amt.deltaker.bff.internal.registerInternalApi
 import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
 import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
 import no.nav.amt.deltaker.bff.sporbarhet.SporbarhetsloggService
+import no.nav.amt.deltaker.bff.testdata.TestdataService
+import no.nav.amt.deltaker.bff.testdata.registerTestdataApi
 import no.nav.amt.deltaker.bff.tiltakskoordinator.TiltakskoordinatorService
 import no.nav.amt.deltaker.bff.tiltakskoordinator.api.registerTiltakskoordinatorDeltakerApi
 import no.nav.amt.deltaker.bff.tiltakskoordinator.api.registerTiltakskoordinatorDeltakerlisteApi
@@ -55,6 +58,7 @@ fun Application.configureRouting(
     deltakerlisteService: DeltakerlisteService,
     unleash: Unleash,
     tiltakskoordinatorService: TiltakskoordinatorService,
+    testdataService: TestdataService,
 ) {
     install(StatusPages) {
         exception<IllegalArgumentException> { call, cause ->
@@ -144,6 +148,10 @@ fun Application.configureRouting(
             tilgangskontrollService,
             sporbarhetsloggService,
         )
+
+        if (!Environment.isProd()) {
+            registerTestdataApi(testdataService)
+        }
 
         val catchAllRoute = "{...}"
         route(catchAllRoute) {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/auth/PreAuthorizedApp.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/auth/PreAuthorizedApp.kt
@@ -1,0 +1,12 @@
+package no.nav.amt.deltaker.bff.auth
+
+import kotlin.collections.last
+import kotlin.text.split
+
+data class PreAuthorizedApp(
+    val name: String,
+    val clientId: String,
+) {
+    val appName = name.split(":").last()
+    val team = name.split(":")[1]
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/forslag/kafka/ArrangorMeldingProducer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/forslag/kafka/ArrangorMeldingProducer.kt
@@ -3,12 +3,12 @@ package no.nav.amt.deltaker.bff.deltaker.forslag.kafka
 import no.nav.amt.deltaker.bff.Environment
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.lib.kafka.Producer
-import no.nav.amt.lib.models.arrangor.melding.Forslag
+import no.nav.amt.lib.models.arrangor.melding.Melding
 
 class ArrangorMeldingProducer(
     private val producer: Producer<String, String>,
 ) {
-    fun produce(forslag: Forslag) {
-        producer.produce(Environment.ARRANGOR_MELDING_TOPIC, forslag.id.toString(), objectMapper.writeValueAsString(forslag))
+    fun produce(melding: Melding) {
+        producer.produce(Environment.ARRANGOR_MELDING_TOPIC, melding.id.toString(), objectMapper.writeValueAsString(melding))
     }
 }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/OpprettTestDeltakelseRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/OpprettTestDeltakelseRequest.kt
@@ -1,0 +1,19 @@
+package no.nav.amt.deltaker.bff.testdata
+
+import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDagerPerUke
+import no.nav.amt.deltaker.bff.deltaker.api.utils.validerDeltakelsesProsent
+import java.time.LocalDate
+import java.util.UUID
+
+data class OpprettTestDeltakelseRequest(
+    val personident: String,
+    val deltakerlisteId: UUID,
+    val startdato: LocalDate,
+    val deltakelsesprosent: Int,
+    val dagerPerUke: Int?,
+) {
+    fun valider() {
+        validerDeltakelsesProsent(deltakelsesprosent)
+        validerDagerPerUke(dagerPerUke)
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataApi.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataApi.kt
@@ -1,0 +1,22 @@
+package no.nav.amt.deltaker.bff.testdata
+
+import io.ktor.server.auth.authenticate
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.post
+import no.nav.amt.deltaker.bff.application.plugins.AuthLevel
+
+// Brukes av team tiltakspenger for å lage testdata for manuell testing i dev.
+// På sikt kan dette kanskje tilbys til Dolly.
+fun Routing.registerTestdataApi(testdataService: TestdataService) {
+    authenticate(AuthLevel.SYSTEM.name) {
+        post("/testdata/opprett") {
+            val request = call.receive<OpprettTestDeltakelseRequest>()
+            request.valider()
+            val deltaker = testdataService.opprettDeltakelse(request)
+
+            call.respond(deltaker)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataService.kt
@@ -30,7 +30,7 @@ class TestdataService(
     private val deltakerService: DeltakerService,
 ) {
     suspend fun opprettDeltakelse(opprettTestDeltakelseRequest: OpprettTestDeltakelseRequest): Deltaker {
-        deltakerFinnesFraAllerede(opprettTestDeltakelseRequest)
+        deltakerFinnesAllerede(opprettTestDeltakelseRequest)
         val deltakerliste = deltakerlisteService.get(opprettTestDeltakelseRequest.deltakerlisteId).getOrThrow()
         val forventetSluttdato = opprettTestDeltakelseRequest.startdato.plusMonths(3)
         valider(
@@ -63,7 +63,7 @@ class TestdataService(
         return deltakerService.get(deltakerId).getOrThrow()
     }
 
-    private fun deltakerFinnesFraAllerede(opprettTestDeltakelseRequest: OpprettTestDeltakelseRequest) {
+    private fun deltakerFinnesAllerede(opprettTestDeltakelseRequest: OpprettTestDeltakelseRequest) {
         val eksisterendeDeltaker = deltakerService
             .getDeltakelser(opprettTestDeltakelseRequest.personident, opprettTestDeltakelseRequest.deltakerlisteId)
             .firstOrNull { !it.harSluttet() }

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataService.kt
@@ -1,0 +1,123 @@
+package no.nav.amt.deltaker.bff.testdata
+
+import kotlinx.coroutines.delay
+import no.nav.amt.deltaker.bff.deltaker.DeltakerService
+import no.nav.amt.deltaker.bff.deltaker.PameldingService
+import no.nav.amt.deltaker.bff.deltaker.forslag.kafka.ArrangorMeldingProducer
+import no.nav.amt.deltaker.bff.deltaker.model.Deltaker
+import no.nav.amt.deltaker.bff.deltaker.model.Pamelding
+import no.nav.amt.deltaker.bff.deltaker.model.Utkast
+import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteService
+import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.toInnhold
+import no.nav.amt.lib.models.arrangor.melding.EndringFraArrangor
+import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
+import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+const val TESTVEILEDER = "Z990098"
+const val TESTENHET = "0314"
+
+// Plutselig Lagsport
+const val TESTARRANGORANSATT = "fff9a665-cbde-4dbc-9ef9-deb8681a0d6f"
+
+class TestdataService(
+    private val pameldingService: PameldingService,
+    private val deltakerlisteService: DeltakerlisteService,
+    private val arrangorMeldingProducer: ArrangorMeldingProducer,
+    private val deltakerService: DeltakerService,
+) {
+    suspend fun opprettDeltakelse(opprettTestDeltakelseRequest: OpprettTestDeltakelseRequest): Deltaker {
+        val deltakerliste = deltakerlisteService.get(opprettTestDeltakelseRequest.deltakerlisteId).getOrThrow()
+        val forventetSluttdato = opprettTestDeltakelseRequest.startdato.plusMonths(3)
+        valider(
+            startdato = opprettTestDeltakelseRequest.startdato,
+            sluttdato = forventetSluttdato,
+            deltakerliste = deltakerliste,
+        )
+        val kladd = pameldingService.opprettKladd(
+            deltakerlisteId = opprettTestDeltakelseRequest.deltakerlisteId,
+            personident = opprettTestDeltakelseRequest.personident,
+        )
+        val deltakerId = kladd.id
+
+        delay(10)
+
+        val utkast = getUtkast(deltakerId, deltakerliste, opprettTestDeltakelseRequest)
+        pameldingService.upsertUtkast(utkast)
+
+        delay(100)
+
+        val endringFraArrangor = getEndringFraArrangor(
+            deltakerId = deltakerId,
+            startdato = opprettTestDeltakelseRequest.startdato,
+            sluttdato = forventetSluttdato,
+        )
+        arrangorMeldingProducer.produce(endringFraArrangor)
+
+        delay(100)
+
+        return deltakerService.get(deltakerId).getOrThrow()
+    }
+
+    private fun valider(
+        startdato: LocalDate,
+        sluttdato: LocalDate,
+        deltakerliste: Deltakerliste,
+    ) {
+        if (deltakerliste.tiltak.tiltakskode != Tiltakstype.Tiltakskode.ARBEIDSFORBEREDENDE_TRENING) {
+            throw IllegalArgumentException("Det er kun AFT som er støttet for testdeltakelser inntil videre")
+        }
+        if (startdato.isBefore(deltakerliste.startDato)) {
+            throw IllegalArgumentException("Kan ikke sette startdato tidligere enn gjennomføringens startdato")
+        }
+        if (deltakerliste.sluttDato != null && sluttdato.isAfter(deltakerliste.sluttDato)) {
+            throw IllegalArgumentException("Kan ikke sette sluttdato senere enn gjennomføringens sluttdato")
+        }
+    }
+
+    private fun getEndringFraArrangor(
+        deltakerId: UUID,
+        startdato: LocalDate,
+        sluttdato: LocalDate,
+    ): EndringFraArrangor = EndringFraArrangor(
+        id = UUID.randomUUID(),
+        deltakerId = deltakerId,
+        opprettetAvArrangorAnsattId = UUID.fromString(TESTARRANGORANSATT),
+        opprettet = LocalDateTime.now(),
+        endring = EndringFraArrangor.LeggTilOppstartsdato(
+            startdato = startdato,
+            sluttdato = sluttdato,
+        ),
+    )
+
+    private fun getUtkast(
+        deltakerId: UUID,
+        deltakerliste: Deltakerliste,
+        opprettTestDeltakelseRequest: OpprettTestDeltakelseRequest,
+    ): Utkast {
+        return Utkast(
+            deltakerId = deltakerId,
+            pamelding = Pamelding(
+                deltakelsesinnhold = getInnhold(deltakerliste),
+                bakgrunnsinformasjon = null,
+                deltakelsesprosent = opprettTestDeltakelseRequest.deltakelsesprosent.toFloat(),
+                dagerPerUke = opprettTestDeltakelseRequest.dagerPerUke?.toFloat(),
+                endretAv = TESTVEILEDER,
+                endretAvEnhet = TESTENHET,
+            ),
+            godkjentAvNav = true,
+        )
+    }
+
+    private fun getInnhold(deltakerliste: Deltakerliste): Deltakelsesinnhold {
+        val innhold = deltakerliste.tiltak.innhold
+        val valgtInnhold = innhold?.innholdselementer?.firstOrNull()?.toInnhold(valgt = true)
+        return Deltakelsesinnhold(
+            ledetekst = innhold?.ledetekst,
+            innhold = valgtInnhold?.let { listOf(it) } ?: emptyList(),
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataService.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataService.kt
@@ -45,12 +45,12 @@ class TestdataService(
 
         delay(10)
 
-        val utkast = getUtkast(deltakerId, deltakerliste, opprettTestDeltakelseRequest)
+        val utkast = lagUtkast(deltakerId, deltakerliste, opprettTestDeltakelseRequest)
         pameldingService.upsertUtkast(utkast)
 
         delay(100)
 
-        val endringFraArrangor = getEndringFraArrangor(
+        val endringFraArrangor = lagEndringFraArrangor(
             deltakerId = deltakerId,
             startdato = opprettTestDeltakelseRequest.startdato,
             sluttdato = forventetSluttdato,
@@ -78,7 +78,7 @@ class TestdataService(
         }
     }
 
-    private fun getEndringFraArrangor(
+    private fun lagEndringFraArrangor(
         deltakerId: UUID,
         startdato: LocalDate,
         sluttdato: LocalDate,
@@ -93,7 +93,7 @@ class TestdataService(
         ),
     )
 
-    private fun getUtkast(
+    private fun lagUtkast(
         deltakerId: UUID,
         deltakerliste: Deltakerliste,
         opprettTestDeltakelseRequest: OpprettTestDeltakelseRequest,
@@ -101,7 +101,7 @@ class TestdataService(
         return Utkast(
             deltakerId = deltakerId,
             pamelding = Pamelding(
-                deltakelsesinnhold = getInnhold(deltakerliste),
+                deltakelsesinnhold = lagInnhold(deltakerliste),
                 bakgrunnsinformasjon = null,
                 deltakelsesprosent = opprettTestDeltakelseRequest.deltakelsesprosent.toFloat(),
                 dagerPerUke = opprettTestDeltakelseRequest.dagerPerUke?.toFloat(),
@@ -112,7 +112,7 @@ class TestdataService(
         )
     }
 
-    private fun getInnhold(deltakerliste: Deltakerliste): Deltakelsesinnhold {
+    private fun lagInnhold(deltakerliste: Deltakerliste): Deltakelsesinnhold {
         val innhold = deltakerliste.tiltak.innhold
         val valgtInnhold = innhold?.innholdselementer?.firstOrNull()?.toInnhold(valgt = true)
         return Deltakelsesinnhold(

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/ApplicationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/ApplicationTest.kt
@@ -34,6 +34,7 @@ class ApplicationTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
         }
         client.get("/internal/health/liveness").apply {

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/application/plugins/AuthenticationTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/application/plugins/AuthenticationTest.kt
@@ -123,6 +123,7 @@ class AuthenticationTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
             setUpTestRoute()
         }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/PameldingApiTest.kt
@@ -301,6 +301,7 @@ class PameldingApiTest {
                 deltakerlisteService,
                 mockk(),
                 mockk(),
+                mockk(),
             )
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/TiltakskoordinatorDeltakerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/TiltakskoordinatorDeltakerApiTest.kt
@@ -763,6 +763,7 @@ class TiltakskoordinatorDeltakerApiTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/utils/Requests.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/deltaker/api/utils/Requests.kt
@@ -8,6 +8,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.deltaker.bff.utils.generateJWT
+import no.nav.amt.deltaker.bff.utils.generateSystemJWT
 import java.util.UUID
 
 internal fun HttpRequestBuilder.postRequest(body: Any) {
@@ -70,4 +71,18 @@ internal fun HttpRequestBuilder.noBodyTiltakskoordinatorRequest() {
         }",
     )
     header("aktiv-enhet", "0101")
+}
+
+internal fun HttpRequestBuilder.systemPostRequest(body: Any) {
+    header(
+        HttpHeaders.Authorization,
+        "Bearer ${
+            generateSystemJWT(
+                consumerClientId = "tiltakspenger-tiltak",
+                audience = "deltaker-bff",
+            )
+        }",
+    )
+    contentType(ContentType.Application.Json)
+    setBody(objectMapper.writeValueAsString(body))
 }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/innbygger/InnbyggerApiTest.kt
@@ -219,6 +219,7 @@ class InnbyggerApiTest {
                 mockk(),
                 mockk(),
                 mockk(),
+                mockk(),
             )
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataApiTest.kt
@@ -1,0 +1,116 @@
+package no.nav.amt.deltaker.bff.testdata
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.amt.deltaker.bff.Environment
+import no.nav.amt.deltaker.bff.application.plugins.configureAuthentication
+import no.nav.amt.deltaker.bff.application.plugins.configureRouting
+import no.nav.amt.deltaker.bff.application.plugins.configureSerialization
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.deltaker.api.utils.systemPostRequest
+import no.nav.amt.deltaker.bff.utils.configureEnvForAuthentication
+import no.nav.amt.deltaker.bff.utils.data.TestData
+import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+class TestdataApiTest {
+    private val testdataService = mockk<TestdataService>()
+
+    @Before
+    fun setup() {
+        configureEnvForAuthentication()
+    }
+
+    @Test
+    fun `opprett testdata - mangler token - returnerer 401`() = testApplication {
+        setUpTestApplication()
+        client.post("/testdata/opprett") { setBody("foo") }.status shouldBe HttpStatusCode.Unauthorized
+    }
+
+    @Test
+    fun `opprett testdata - har tilgang, ugyldig request - returnerer BadRequest`() = testApplication {
+        val deltakerliste = TestData.lagDeltakerliste(
+            tiltak = TestData.lagTiltakstype(tiltakskode = Tiltakstype.Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
+        )
+        val startdato = LocalDate.now().minusDays(1)
+        val opprettTestDeltakelseRequest = OpprettTestDeltakelseRequest(
+            personident = TestData.randomIdent(),
+            deltakerlisteId = deltakerliste.id,
+            startdato = startdato,
+            deltakelsesprosent = 100,
+            dagerPerUke = 7,
+        )
+
+        setUpTestApplication()
+
+        client.post("/testdata/opprett") { systemPostRequest(opprettTestDeltakelseRequest) }.apply {
+            status shouldBe HttpStatusCode.BadRequest
+        }
+    }
+
+    @Test
+    fun `opprett testdata - har tilgang, gyldig request - returnerer deltaker`() = testApplication {
+        val deltakerliste = TestData.lagDeltakerliste(
+            tiltak = TestData.lagTiltakstype(tiltakskode = Tiltakstype.Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
+        )
+        val startdato = LocalDate.now().minusDays(1)
+        val deltaker = TestData.lagDeltaker(
+            deltakerliste = deltakerliste,
+            startdato = startdato,
+            sluttdato = startdato.plusMonths(3),
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.DELTAR),
+            deltakelsesprosent = 50F,
+            dagerPerUke = 3F,
+        )
+        val opprettTestDeltakelseRequest = OpprettTestDeltakelseRequest(
+            personident = deltaker.navBruker.personident,
+            deltakerlisteId = deltaker.deltakerliste.id,
+            startdato = startdato,
+            deltakelsesprosent = deltaker.deltakelsesprosent?.toInt()!!,
+            dagerPerUke = deltaker.dagerPerUke?.toInt(),
+        )
+
+        coEvery { testdataService.opprettDeltakelse(any()) } returns deltaker
+
+        setUpTestApplication()
+
+        client.post("/testdata/opprett") { systemPostRequest(opprettTestDeltakelseRequest) }.apply {
+            status shouldBe HttpStatusCode.OK
+            bodyAsText() shouldBe objectMapper.writeValueAsString(deltaker)
+        }
+    }
+
+    private fun ApplicationTestBuilder.setUpTestApplication() {
+        application {
+            configureSerialization()
+            configureAuthentication(Environment())
+            configureRouting(
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                testdataService,
+            )
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/testdata/TestdataServiceTest.kt
@@ -1,0 +1,144 @@
+package no.nav.amt.deltaker.bff.testdata
+
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.amt.deltaker.bff.deltaker.DeltakerService
+import no.nav.amt.deltaker.bff.deltaker.PameldingService
+import no.nav.amt.deltaker.bff.deltaker.db.DeltakerRepository
+import no.nav.amt.deltaker.bff.deltaker.forslag.kafka.ArrangorMeldingProducer
+import no.nav.amt.deltaker.bff.deltaker.navbruker.NavBrukerRepository
+import no.nav.amt.deltaker.bff.deltaker.navbruker.NavBrukerService
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteRepository
+import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteService
+import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.toInnhold
+import no.nav.amt.deltaker.bff.navansatt.NavAnsattRepository
+import no.nav.amt.deltaker.bff.navansatt.NavAnsattService
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetRepository
+import no.nav.amt.deltaker.bff.navansatt.navenhet.NavEnhetService
+import no.nav.amt.deltaker.bff.utils.MockResponseHandler
+import no.nav.amt.deltaker.bff.utils.data.TestData
+import no.nav.amt.deltaker.bff.utils.data.TestRepository
+import no.nav.amt.deltaker.bff.utils.mockAmtDeltakerClient
+import no.nav.amt.deltaker.bff.utils.mockAmtPersonServiceClient
+import no.nav.amt.lib.models.arrangor.melding.EndringFraArrangor
+import no.nav.amt.lib.models.deltaker.Deltakelsesinnhold
+import no.nav.amt.lib.models.deltaker.DeltakerStatus
+import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
+import no.nav.amt.lib.testing.SingletonPostgres16Container
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import java.time.LocalDate
+
+class TestdataServiceTest {
+    companion object {
+        private val navAnsattService = NavAnsattService(NavAnsattRepository(), mockAmtPersonServiceClient())
+        private val navEnhetService = NavEnhetService(NavEnhetRepository(), mockAmtPersonServiceClient())
+        private val deltakerService = DeltakerService(
+            deltakerRepository = DeltakerRepository(),
+            amtDeltakerClient = mockAmtDeltakerClient(),
+            navEnhetService = navEnhetService,
+            forslagService = mockk(),
+        )
+        private val deltakerlisteService = DeltakerlisteService(DeltakerlisteRepository(), mockAmtPersonServiceClient())
+        private var pameldingService = PameldingService(
+            deltakerService = deltakerService,
+            navBrukerService = NavBrukerService(mockAmtPersonServiceClient(), NavBrukerRepository(), navAnsattService, navEnhetService),
+            amtDeltakerClient = mockAmtDeltakerClient(),
+            navEnhetService = navEnhetService,
+        )
+        private val arrangorMeldingProducer = mockk<ArrangorMeldingProducer>(relaxed = true)
+        private val testdataService = TestdataService(
+            pameldingService = pameldingService,
+            deltakerService = deltakerService,
+            deltakerlisteService = deltakerlisteService,
+            arrangorMeldingProducer = arrangorMeldingProducer,
+        )
+
+        @JvmStatic
+        @BeforeClass
+        fun setup() {
+            SingletonPostgres16Container
+        }
+    }
+
+    @Before
+    fun cleanDatabase() {
+        TestRepository.cleanDatabase()
+        clearMocks(arrangorMeldingProducer)
+    }
+
+    @Test
+    fun `opprettDeltakelse - deltaker finnes ikke, gyldig request - oppretter ny deltaker`() {
+        val arrangor = TestData.lagArrangor()
+        val deltakerliste = TestData.lagDeltakerliste(
+            arrangor = arrangor,
+            tiltak = TestData.lagTiltakstype(tiltakskode = Tiltakstype.Tiltakskode.ARBEIDSFORBEREDENDE_TRENING),
+        )
+        val opprettetAv = TestData.lagNavAnsatt(navIdent = TESTVEILEDER)
+        val opprettetAvEnhet = TestData.lagNavEnhet(enhetsnummer = TESTENHET)
+        TestRepository.insert(opprettetAv)
+        TestRepository.insert(opprettetAvEnhet)
+        val navBruker = TestData.lagNavBruker(navVeilederId = opprettetAv.id, navEnhetId = opprettetAvEnhet.id)
+
+        val opprettTestDeltakelseRequest = OpprettTestDeltakelseRequest(
+            personident = navBruker.personident,
+            deltakerlisteId = deltakerliste.id,
+            startdato = LocalDate.now().minusDays(1),
+            deltakelsesprosent = 60,
+            dagerPerUke = 3,
+        )
+
+        val kladd = TestData.lagDeltakerKladd(
+            deltakerliste = deltakerliste,
+            navBruker = navBruker,
+        )
+        val godkjentUtkast = kladd.copy(
+            dagerPerUke = opprettTestDeltakelseRequest.dagerPerUke?.toFloat(),
+            deltakelsesprosent = opprettTestDeltakelseRequest.deltakelsesprosent.toFloat(),
+            bakgrunnsinformasjon = null,
+            status = TestData.lagDeltakerStatus(type = DeltakerStatus.Type.VENTER_PA_OPPSTART),
+            kanEndres = true,
+            deltakelsesinnhold = Deltakelsesinnhold(
+                ledetekst = deltakerliste.tiltak.innhold!!.ledetekst,
+                innhold = listOf(deltakerliste.tiltak.innhold!!.innholdselementer.first().toInnhold(valgt = true)),
+            ),
+        )
+
+        TestRepository.insert(deltakerliste)
+        MockResponseHandler.addOpprettKladdResponse(kladd)
+        MockResponseHandler.addUtkastResponse(godkjentUtkast)
+
+        runBlocking {
+            val deltaker = testdataService.opprettDeltakelse(opprettTestDeltakelseRequest)
+
+            val deltakerFraDb = deltakerService.getDeltakelser(navBruker.personident, deltakerliste.id).first()
+            deltakerFraDb.id shouldBe deltaker.id
+            deltakerFraDb.deltakerliste.id shouldBe deltakerliste.id
+            deltakerFraDb.status.type shouldBe DeltakerStatus.Type.VENTER_PA_OPPSTART
+            deltakerFraDb.startdato shouldBe null
+            deltakerFraDb.sluttdato shouldBe null
+            deltakerFraDb.dagerPerUke shouldBe opprettTestDeltakelseRequest.dagerPerUke?.toFloat()
+            deltakerFraDb.deltakelsesprosent shouldBe opprettTestDeltakelseRequest.deltakelsesprosent.toFloat()
+            deltakerFraDb.bakgrunnsinformasjon shouldBe null
+            deltakerFraDb.deltakelsesinnhold?.ledetekst shouldBe deltakerliste.tiltak.innhold!!.ledetekst
+            deltakerFraDb.deltakelsesinnhold?.innhold?.size shouldBe 1
+
+            coEvery {
+                arrangorMeldingProducer.produce(
+                    match {
+                        it is EndringFraArrangor && it.deltakerId == deltaker.id &&
+                            it.opprettetAvArrangorAnsattId.toString() == TESTARRANGORANSATT &&
+                            it.endring == EndringFraArrangor.LeggTilOppstartsdato(
+                                startdato = opprettTestDeltakelseRequest.startdato,
+                                sluttdato = opprettTestDeltakelseRequest.startdato.plusMonths(3),
+                            )
+                    },
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorDeltakerlisteApiTest.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/tiltakskoordinator/TiltakskoordinatorDeltakerlisteApiTest.kt
@@ -307,6 +307,7 @@ class TiltakskoordinatorDeltakerlisteApiTest {
                 deltakerlisteService,
                 mockk(),
                 tiltakskoordinatorService,
+                mockk(),
             )
         }
     }

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/JWTUtils.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/JWTUtils.kt
@@ -53,6 +53,36 @@ fun generateJWT(
         .sign(alg)
 }
 
+fun generateSystemJWT(
+    consumerClientId: String,
+    audience: String,
+    expiry: LocalDateTime? = LocalDateTime.now().plusHours(1),
+    subject: String = "subject",
+    issuer: String = "issuer",
+    groups: List<String> = emptyList(),
+): String? {
+    val now = Date()
+    val key = getDefaultRSAKey()
+    val alg = Algorithm.RSA256(key.toRSAPublicKey(), key.toRSAPrivateKey())
+
+    return JWT.create()
+        .withKeyId(KEY_ID)
+        .withSubject(subject)
+        .withIssuer(issuer)
+        .withAudience(audience)
+        .withJWTId(UUID.randomUUID().toString())
+        .withClaim("ver", "1.0")
+        .withClaim("nonce", "myNonce")
+        .withClaim("auth_time", now)
+        .withClaim("nbf", now)
+        .withClaim("azp", consumerClientId)
+        .withClaim("oid", subject)
+        .withClaim("iat", now)
+        .withClaim("exp", Date.from(expiry?.atZone(ZoneId.systemDefault())?.toInstant()))
+        .withClaim("groups", groups)
+        .sign(alg)
+}
+
 fun tokenXToken(pid: String, env: Environment): String? {
     val key = getDefaultRSAKey()
     return JWT.create()

--- a/src/test/kotlin/no/nav/amt/deltaker/bff/utils/TestEnvironmentUtils.kt
+++ b/src/test/kotlin/no/nav/amt/deltaker/bff/utils/TestEnvironmentUtils.kt
@@ -1,12 +1,15 @@
 package no.nav.amt.deltaker.bff.utils
 
 import no.nav.amt.deltaker.bff.Environment
+import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.auth.PreAuthorizedApp
 import java.nio.file.Paths
 import java.util.UUID
 
 fun configureEnvForAuthentication() {
     val path = "src/test/resources/jwkset.json"
     val uri = Paths.get(path).toUri().toURL().toString()
+    val preAuthorizedApp = PreAuthorizedApp("dev:tpts:tiltakspenger-tiltak", "tiltakspenger-tiltak")
     System.setProperty(Environment.AZURE_OPENID_CONFIG_JWKS_URI_KEY, uri)
     System.setProperty(Environment.AZURE_OPENID_CONFIG_ISSUER_KEY, "issuer")
     System.setProperty(Environment.AZURE_APP_CLIENT_ID_KEY, "deltaker-bff")
@@ -14,4 +17,5 @@ fun configureEnvForAuthentication() {
     System.setProperty(Environment.TOKEN_X_ISSUER_KEY, "issuer")
     System.setProperty(Environment.TOKEN_X_CLIENT_ID_KEY, "deltaker-bff")
     System.setProperty(Environment.AD_ROLLE_TILTAKSKOORDINATOR, UUID(0L, 0L).toString())
+    System.setProperty(Environment.AZURE_APP_PRE_AUTHORIZED_APPS, objectMapper.writeValueAsString(listOf(preAuthorizedApp)))
 }


### PR DESCRIPTION
Dette er det samme apiet som vi forsøkte å opprette i amt-deltaker, men som vi må flytte fordi deltaker-bff ikke liker å få deltakere som den ikke kjenner fra før og som ikke er arena-deltakere. 

Apiet skal brukes for å opprette tiltaksdeltakelser på testbrukere i dev slik at team tiltakspenger kan fortsette vanlig manuell testing uten å måtte sette seg inn i hele verdikjeden for hvordan man melder noen på tiltak. Det er fortsatt kun AFT som støttes, og det er veldig begrenset hva vi tillater av input så ikke vi i tiltakspenger skal skape rot i testmiljøet deres :D 

På sikt kan det sikkert bygges ut med andre tiltak (gruppeamo står nok på vår fremtidige ønskeliste) og kanskje Dolly kan bruke det etterhvert så man kan opprette testbrukere som deltar på tiltak direkte, hvis andre team også har behov for det. 