### PR TITLE
Bump dependencies - 20250707091735

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ val caffeineVersion = "3.2.1"
 val mockkVersion = "1.14.4"
 val nimbusVersion = "10.3.1"
 val amtLibVersion = "1.2025.06.30_11.34-39810db912fa"
-val unleashVersion = "11.0.1"
+val unleashVersion = "11.0.2"
 
 dependencies {
     implementation("io.ktor:ktor-server-content-negotiation-jvm")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     val kotlinVersion = "2.2.0"
 
     kotlin("jvm") version kotlinVersion
-    id("io.ktor.plugin") version "3.2.0"
+    id("io.ktor.plugin") version "3.2.1"
     id("org.jetbrains.kotlin.plugin.serialization") version kotlinVersion
     id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
     id("com.gradleup.shadow") version "8.3.8"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250707091735 branch:

## Successfully Rebased PRs
- [Bump io.ktor.plugin from 3.2.0 to 3.2.1](https://github.com/navikt/amt-deltaker-bff/pull/598)
- [Bump io.getunleash:unleash-client-java from 11.0.1 to 11.0.2](https://github.com/navikt/amt-deltaker-bff/pull/597)


