### PR TITLE
Refakturert bort duplikatkode i Kafka Consumer-klasser

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/arrangor/ArrangorConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/arrangor/ArrangorConsumer.kt
@@ -3,30 +3,19 @@ package no.nav.amt.deltaker.bff.arrangor
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.amt.deltaker.bff.Environment
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.utils.buildManagedKafkaConsumer
 import no.nav.amt.lib.kafka.Consumer
-import no.nav.amt.lib.kafka.ManagedKafkaConsumer
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
-import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.kafka.common.serialization.UUIDDeserializer
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class ArrangorConsumer(
     private val repository: ArrangorRepository,
-    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
 ) : Consumer<UUID, String?> {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val consumer = ManagedKafkaConsumer(
+    private val consumer = buildManagedKafkaConsumer(
         topic = Environment.AMT_ARRANGOR_TOPIC,
-        config = kafkaConfig.consumerConfig(
-            keyDeserializer = UUIDDeserializer(),
-            valueDeserializer = StringDeserializer(),
-            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
-        ),
-        consume = ::consume,
+        consumeFunc = ::consume,
     )
 
     override suspend fun consume(key: UUID, value: String?) {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/forslag/kafka/ArrangorMeldingConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/forslag/kafka/ArrangorMeldingConsumer.kt
@@ -4,33 +4,22 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.amt.deltaker.bff.Environment
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.deltaker.bff.deltaker.forslag.ForslagService
+import no.nav.amt.deltaker.bff.utils.buildManagedKafkaConsumer
 import no.nav.amt.lib.kafka.Consumer
-import no.nav.amt.lib.kafka.ManagedKafkaConsumer
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.arrangor.melding.Forslag
 import no.nav.amt.lib.models.arrangor.melding.Melding
-import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.kafka.common.serialization.UUIDDeserializer
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class ArrangorMeldingConsumer(
     private val forslagService: ForslagService,
     private val isDev: Boolean = Environment.isDev(),
-    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl("earliest"),
 ) : Consumer<UUID, String?> {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val consumer = ManagedKafkaConsumer(
+    private val consumer = buildManagedKafkaConsumer(
         topic = Environment.ARRANGOR_MELDING_TOPIC,
-        config = kafkaConfig.consumerConfig(
-            keyDeserializer = UUIDDeserializer(),
-            valueDeserializer = StringDeserializer(),
-            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
-        ),
-        consume = ::consume,
+        consumeFunc = ::consume,
     )
 
     override suspend fun consume(key: UUID, value: String?) {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/kafka/DeltakerV2Consumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/kafka/DeltakerV2Consumer.kt
@@ -8,13 +8,8 @@ import no.nav.amt.deltaker.bff.deltaker.navbruker.NavBrukerService
 import no.nav.amt.deltaker.bff.deltaker.vurdering.VurderingService
 import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.bff.unleash.UnleashToggle
+import no.nav.amt.deltaker.bff.utils.buildManagedKafkaConsumer
 import no.nav.amt.lib.kafka.Consumer
-import no.nav.amt.lib.kafka.ManagedKafkaConsumer
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
-import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.kafka.common.serialization.UUIDDeserializer
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
@@ -24,18 +19,12 @@ class DeltakerV2Consumer(
     private val vurderingService: VurderingService,
     private val navBrukerService: NavBrukerService,
     private val unleashToggle: UnleashToggle,
-    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
 ) : Consumer<UUID, String?> {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val consumer = ManagedKafkaConsumer(
+    private val consumer = buildManagedKafkaConsumer(
         topic = Environment.AMT_DELTAKERV2_TOPIC,
-        config = kafkaConfig.consumerConfig(
-            keyDeserializer = UUIDDeserializer(),
-            valueDeserializer = StringDeserializer(),
-            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
-        ),
-        consume = ::consume,
+        consumeFunc = ::consume,
     )
 
     override suspend fun consume(key: UUID, value: String?) {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/navbruker/NavBrukerConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/navbruker/NavBrukerConsumer.kt
@@ -5,31 +5,20 @@ import no.nav.amt.deltaker.bff.Environment
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.deltaker.bff.deltaker.PameldingService
 import no.nav.amt.deltaker.bff.navansatt.NavBrukerDto
+import no.nav.amt.deltaker.bff.utils.buildManagedKafkaConsumer
 import no.nav.amt.lib.kafka.Consumer
-import no.nav.amt.lib.kafka.ManagedKafkaConsumer
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
-import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.kafka.common.serialization.UUIDDeserializer
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class NavBrukerConsumer(
     private val navBrukerService: NavBrukerService,
     private val pameldingService: PameldingService,
-    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl("earliest"),
 ) : Consumer<UUID, String?> {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val consumer = ManagedKafkaConsumer(
+    private val consumer = buildManagedKafkaConsumer(
         topic = Environment.AMT_NAV_BRUKER_TOPIC,
-        config = kafkaConfig.consumerConfig(
-            keyDeserializer = UUIDDeserializer(),
-            valueDeserializer = StringDeserializer(),
-            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
-        ),
-        consume = ::consume,
+        consumeFunc = ::consume,
     )
 
     override suspend fun consume(key: UUID, value: String?) {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/kafka/DeltakerlisteConsumer.kt
@@ -9,14 +9,9 @@ import no.nav.amt.deltaker.bff.deltaker.PameldingService
 import no.nav.amt.deltaker.bff.deltakerliste.Deltakerliste
 import no.nav.amt.deltaker.bff.deltakerliste.DeltakerlisteRepository
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.TiltakstypeRepository
+import no.nav.amt.deltaker.bff.utils.buildManagedKafkaConsumer
 import no.nav.amt.lib.kafka.Consumer
-import no.nav.amt.lib.kafka.ManagedKafkaConsumer
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.Tiltakstype
-import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.kafka.common.serialization.UUIDDeserializer
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
@@ -26,18 +21,12 @@ class DeltakerlisteConsumer(
     private val tiltakstypeRepository: TiltakstypeRepository,
     private val pameldingService: PameldingService,
     private val tilgangskontrollService: TilgangskontrollService,
-    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
 ) : Consumer<UUID, String?> {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val consumer = ManagedKafkaConsumer(
+    private val consumer = buildManagedKafkaConsumer(
         topic = Environment.DELTAKERLISTE_TOPIC,
-        config = kafkaConfig.consumerConfig(
-            keyDeserializer = UUIDDeserializer(),
-            valueDeserializer = StringDeserializer(),
-            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
-        ),
-        consume = ::consume,
+        consumeFunc = ::consume,
     )
 
     override fun start() = consumer.start()

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/tiltakstype/kafka/TiltakstypeConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltakerliste/tiltakstype/kafka/TiltakstypeConsumer.kt
@@ -4,37 +4,27 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.amt.deltaker.bff.Environment
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
 import no.nav.amt.deltaker.bff.deltakerliste.tiltakstype.TiltakstypeRepository
+import no.nav.amt.deltaker.bff.utils.buildManagedKafkaConsumer
 import no.nav.amt.lib.kafka.Consumer
-import no.nav.amt.lib.kafka.ManagedKafkaConsumer
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
 import no.nav.amt.lib.models.deltakerliste.tiltakstype.kafka.TiltakstypeDto
-import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.kafka.common.serialization.UUIDDeserializer
 import java.util.UUID
 
 class TiltakstypeConsumer(
     private val repository: TiltakstypeRepository,
-    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(autoOffsetReset = "earliest"),
 ) : Consumer<UUID, String?> {
-    private val consumer = ManagedKafkaConsumer(
+    private val consumer = buildManagedKafkaConsumer(
         topic = Environment.TILTAKSTYPE_TOPIC,
-        config = kafkaConfig.consumerConfig(
-            keyDeserializer = UUIDDeserializer(),
-            valueDeserializer = StringDeserializer(),
-            groupId = Environment.KAFKA_CONSUMER_GROUP_ID + "tiltakstyper",
-        ),
-        consume = ::consume,
+        consumerGroupId = Environment.KAFKA_CONSUMER_GROUP_ID + "tiltakstyper",
+        consumeFunc = ::consume,
     )
-
-    override fun start() = consumer.start()
-
-    override suspend fun close() = consumer.close()
 
     override suspend fun consume(key: UUID, value: String?) {
         value?.let { handterTiltakstype(objectMapper.readValue(it)) }
     }
+
+    override fun start() = consumer.start()
+
+    override suspend fun close() = consumer.close()
 
     private fun handterTiltakstype(tiltakstype: TiltakstypeDto) {
         repository.upsert(tiltakstype.toModel())

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/navansatt/NavAnsattConsumer.kt
@@ -3,30 +3,19 @@ package no.nav.amt.deltaker.bff.navansatt
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.amt.deltaker.bff.Environment
 import no.nav.amt.deltaker.bff.application.plugins.objectMapper
+import no.nav.amt.deltaker.bff.utils.buildManagedKafkaConsumer
 import no.nav.amt.lib.kafka.Consumer
-import no.nav.amt.lib.kafka.ManagedKafkaConsumer
-import no.nav.amt.lib.kafka.config.KafkaConfig
-import no.nav.amt.lib.kafka.config.KafkaConfigImpl
-import no.nav.amt.lib.kafka.config.LocalKafkaConfig
-import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.kafka.common.serialization.UUIDDeserializer
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class NavAnsattConsumer(
     private val navAnsattService: NavAnsattService,
-    kafkaConfig: KafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl(),
 ) : Consumer<UUID, String?> {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    private val consumer = ManagedKafkaConsumer(
+    private val consumer = buildManagedKafkaConsumer(
         topic = Environment.AMT_NAV_ANSATT_TOPIC,
-        config = kafkaConfig.consumerConfig(
-            keyDeserializer = UUIDDeserializer(),
-            valueDeserializer = StringDeserializer(),
-            groupId = Environment.KAFKA_CONSUMER_GROUP_ID,
-        ),
-        consume = ::consume,
+        consumeFunc = ::consume,
     )
 
     override suspend fun consume(key: UUID, value: String?) {

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/utils/KafkaConsumerFactory.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/utils/KafkaConsumerFactory.kt
@@ -12,8 +12,11 @@ import java.util.UUID
  * Oppretter instans av [ManagedKafkaConsumer] med [UUID] som nøkkel og
  * nullable [String] som verdi.
  *
- * @param topic
- * @param consumerGroupId
+ * @param topic Navnet på Kafka-topic som det skal lyttes på.
+ * @param consumerGroupId ID-en til consumer-gruppen. Default: [Environment.KAFKA_CONSUMER_GROUP_ID].
+ * @param consumeFunc Funksjon som håndterer mottatte meldinger.
+ *
+ * @return Instans av [ManagedKafkaConsumer] konfigurert for spesifisert topic og consumer group.
  */
 fun buildManagedKafkaConsumer(
     topic: String,
@@ -23,7 +26,7 @@ fun buildManagedKafkaConsumer(
     val kafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl()
 
     return ManagedKafkaConsumer(
-        topic,
+        topic = topic,
         config = kafkaConfig.consumerConfig(
             keyDeserializer = UUIDDeserializer(),
             valueDeserializer = StringDeserializer(),

--- a/src/main/kotlin/no/nav/amt/deltaker/bff/utils/KafkaConsumerFactory.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/utils/KafkaConsumerFactory.kt
@@ -1,0 +1,34 @@
+package no.nav.amt.deltaker.bff.utils
+
+import no.nav.amt.deltaker.bff.Environment
+import no.nav.amt.lib.kafka.ManagedKafkaConsumer
+import no.nav.amt.lib.kafka.config.KafkaConfigImpl
+import no.nav.amt.lib.kafka.config.LocalKafkaConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.UUIDDeserializer
+import java.util.UUID
+
+/**
+ * Oppretter instans av [ManagedKafkaConsumer] med [UUID] som nøkkel og
+ * nullable [String] som verdi.
+ *
+ * @param topic
+ * @param consumerGroupId
+ */
+fun buildManagedKafkaConsumer(
+    topic: String,
+    consumerGroupId: String = Environment.KAFKA_CONSUMER_GROUP_ID,
+    consumeFunc: suspend (key: UUID, value: String?) -> Unit,
+): ManagedKafkaConsumer<UUID, String?> {
+    val kafkaConfig = if (Environment.isLocal()) LocalKafkaConfig() else KafkaConfigImpl()
+
+    return ManagedKafkaConsumer(
+        topic,
+        config = kafkaConfig.consumerConfig(
+            keyDeserializer = UUIDDeserializer(),
+            valueDeserializer = StringDeserializer(),
+            groupId = consumerGroupId,
+        ),
+        consume = consumeFunc,
+    )
+}


### PR DESCRIPTION
Benytter nå factory-methoden `buildManagedKafkaConsumer` for å opprette instanser aV `ManagedKafkaConsumer`.

Planen var å benytte delegate-pattern'et, men det fungerte ikke så godt i dette caset.