### PR TITLE
Bump dependencies - 20250730102733

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ val postgresVersion = "42.7.7"
 val caffeineVersion = "3.2.2"
 val mockkVersion = "1.14.5"
 val nimbusVersion = "10.4"
-val amtLibVersion = "1.2025.07.24_08.56-23b9e28ffd10"
+val amtLibVersion = "1.2025.07.29_08.15-fb5d28e285e4"
 val unleashVersion = "11.0.2"
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
     maven { setUrl("https://github-package-registry-mirror.gc.nav.no/cached/maven-release") }
 }
 
-val ktorVersion = "3.2.2"
+val ktorVersion = "3.2.3"
 val logbackVersion = "1.5.18"
 val prometeusVersion = "1.15.2"
 val ktlintVersion = "1.6.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     val kotlinVersion = "2.2.0"
 
     kotlin("jvm") version kotlinVersion
-    id("io.ktor.plugin") version "3.2.2"
+    id("io.ktor.plugin") version "3.2.3"
     id("org.jetbrains.kotlin.plugin.serialization") version kotlinVersion
     id("org.jlleitschuh.gradle.ktlint") version "13.0.0"
     id("com.gradleup.shadow") version "8.3.8"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250730102733 branch:

## Successfully Rebased PRs
- [Bump ktorVersion from 3.2.2 to 3.2.3](https://github.com/navikt/amt-deltaker-bff/pull/630)
- [Bump amtLibVersion from 1.2025.07.24_08.56-23b9e28ffd10 to 1.2025.07.29_08.15-fb5d28e285e4](https://github.com/navikt/amt-deltaker-bff/pull/629)
- [Bump io.ktor.plugin from 3.2.2 to 3.2.3](https://github.com/navikt/amt-deltaker-bff/pull/628)


