### PR TITLE
Tillate endring av oppstartsdato for flere statuser

### DIFF
--- a/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/EndreStartdatoRequest.kt
+++ b/src/main/kotlin/no/nav/amt/deltaker/bff/deltaker/api/model/EndreStartdatoRequest.kt
@@ -15,7 +15,13 @@ data class EndreStartdatoRequest(
     override val forslagId: UUID?,
 ) : EndringsforslagRequest {
     private val kanEndreStartdato =
-        listOf(DeltakerStatus.Type.VENTER_PA_OPPSTART, DeltakerStatus.Type.DELTAR, DeltakerStatus.Type.HAR_SLUTTET)
+        listOf(
+            DeltakerStatus.Type.VENTER_PA_OPPSTART,
+            DeltakerStatus.Type.DELTAR,
+            DeltakerStatus.Type.HAR_SLUTTET,
+            DeltakerStatus.Type.FULLFORT,
+            DeltakerStatus.Type.AVBRUTT,
+        )
 
     override fun valider(deltaker: Deltaker) {
         validerDeltakerKanEndres(deltaker)


### PR DESCRIPTION
https://trello.com/c/ChkEL3UN/2375-tillate-%C3%A5-endre-oppstartsdato-p%C3%A5-deltakelse-som-er-fullf%C3%B8rt-og-avbrutt